### PR TITLE
Support devices without channels

### DIFF
--- a/index.js
+++ b/index.js
@@ -906,6 +906,10 @@ function ChannelDetector() {
                 channelStates = [id];
             } else if (objects[id].type === 'device') {
                 channelStates = getAllStatesInDevice(keys, id);
+                // if no states, it may be device without channels
+                if (!channelStates.length) {
+                    channelStates = getAllStatesInChannel(keys, id);
+                }
             } else { // channel
                 channelStates = getAllStatesInChannel(keys, id);
             }


### PR DESCRIPTION
In some cases, devices may not have channels, but immediately have a states. For example in the zigbee-adapter.