### PR TITLE
add "white" to rgb

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,6 +193,7 @@ function ChannelDetector() {
                 {role: /^level\.color\.red$/,                             indicator: false, type: 'number',  write: true,           name: 'RED',           required: true,   defaultRole: 'level.color.red'},
                 {role: /^level\.color\.green$/,                           indicator: false, type: 'number',  write: true,           name: 'GREEN',         required: true,   defaultRole: 'level.color.green'},
                 {role: /^level\.color\.blue$/,                            indicator: false, type: 'number',  write: true,           name: 'BLUE',          required: true,   defaultRole: 'level.color.blue'},
+                {role: /^level\.color\.white$/,                           indicator: false, type: 'number',  write: true,           name: 'WHITE',         required: false,  defaultRole: 'level.color.white'},
                 {role: /^level\.dimmer$/,                                 indicator: false, type: 'number',  write: true,           name: 'DIMMER',        required: false,  defaultRole: 'level.dimmer'},
                 {role: /^level\.brightness$/,                             indicator: false, type: 'number',  write: true,           name: 'BRIGHTNESS',    required: false},
                 {role: /^level\.color\.saturation$/,                      indicator: false, type: 'number',  write: true,           name: 'SATURATION',    required: false},


### PR DESCRIPTION
Some devices (shelly) use level.color.white value to change brightness for color modes. They also have a brightness state. I am still not sure what the lamps do, if you control both... but they have those controls and people tend to use them.
Also: if rgb devices is detected the single level.* is detected as "dimmer" which can create issues (like in lovelace adapter there will be multiple devices with same id and if you are not very cautious the dimmer one can "overwrite" the rgb one).
This also might help with issue #7.