### PR TITLE
Fixed problem when read/write properties are string values.

### DIFF
--- a/index.js
+++ b/index.js
@@ -708,7 +708,7 @@ function ChannelDetector() {
                 return;
             }
 
-            if (statePattern.write !== undefined && statePattern.write !== (objects[id].common.write || false)) {
+            if (statePattern.write !== undefined && statePattern.write !== (!!objects[id].common.write || false)) {
                 return;
             }
             if (statePattern.min === 'number' && typeof objects[id].common.min !== 'number') {
@@ -718,7 +718,7 @@ function ChannelDetector() {
                 return;
             }
 
-            if (statePattern.read !== undefined && statePattern.read !== (objects[id].common.read === undefined ? true : objects[id].common.read)) {
+            if (statePattern.read !== undefined && statePattern.read !== (!!objects[id].common.read === undefined ? true : !!objects[id].common.read)) {
                 return;
             }
 


### PR DESCRIPTION
Dieses Paket wird in https://github.com/ioBroker/ioBroker.material verwendet und ich hatte dort ein Problem mit Objekten, die von dem TP-Link HS100 Adapter erzeugt wurden (https://github.com/arteck/ioBroker.hs100). Sie wurden nicht als light erkannte, wenn ich zusätzlich dieses Rolle ergänzt habe. Bei dem Objekt "state" in HS100 werden die read und write Eigenschaften scheinbar als string und nicht als boolean angelegt. Durch die bisherige Verarbeitung hier im Paket wird "true" nicht als true erkannt. Mein commit sollte dabei Abhilfe schaffen.
Ich weiß, dass dies besser in dem HS100 Adapter zu beheben ist :-)
Aber man könnte das Problem hier zusätzlich abfangen.