### PR TITLE
switch.* should be boolean

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,8 +303,8 @@ function ChannelDetector() {
                 // optional
                 {role: /temperature(\..*)?$/,          indicator: false,     write: false, type: 'number',    searchInParent: true,                           name: 'ACTUAL',             required: false, defaultRole: 'value.temperature'},
                 {role: /humidity(\..*)?$/,             indicator: false,     write: false, type: 'number',    searchInParent: true,                           name: 'HUMIDITY',           required: false, defaultRole: 'value.humidity'},
-                {role: /^switch\.boost(\..*)?$/,       indicator: false,     write: true,  type: 'number',    searchInParent: true,                           name: 'BOOST',              required: false, defaultRole: 'switch.boost'},
-                {role: /^switch\.power$/,              indicator: false,     write: true,  type: 'number',    searchInParent: true,                           name: 'POWER',              required: false, defaultRole: 'switch.power'},
+                {role: /^switch\.boost(\..*)?$/,       indicator: false,     write: true,  type: ['boolean', 'number'],   searchInParent: true,                           name: 'BOOST',              required: false, defaultRole: 'switch.boost'},
+                {role: /^switch\.power$/,              indicator: false,     write: true,  type: ['boolean', 'number'],   searchInParent: true,                           name: 'POWER',              required: false, defaultRole: 'switch.power'},
                 patternWorking,
                 patternUnreach,
                 patternLowbat,


### PR DESCRIPTION
thermostat switches were type 'number'. Is this a typo or is there a reason for it? We should at least also accept boolean switches, which should be the default.

If the 'number' thing was a typo, then I can add another commit to delete it. I could not find a thermostat which uses number as a type there, but I'm not sure I searched at the right places.