### PR TITLE
WIP: Refactoring

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,7 +2,7 @@
   "tabWidth": 2,
   "useTabs": false,
   "semi": true,
-  "trailingComma": "all",
+  "trailingComma": "es5",
   "singleQuote": true,
   "printWidth": 80,
   "arrowParens": "avoid"

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "trailingComma": "all",
+  "singleQuote": true,
+  "printWidth": 80,
+  "arrowParens": "avoid"
+}

--- a/index.js
+++ b/index.js
@@ -998,9 +998,6 @@ function ChannelDetector() {
         if (objects[id] && objects[id].common) {
             var channelStates = this._getChannelStates(objects, id, keys);
 
-            /*if (id.indexOf('yeelight-2.0.color-') !== -1) {
-                console.log('aaa');
-            }*/
             var context = {
                 objects:            objects,
                 channelStates:      channelStates,
@@ -1015,19 +1012,11 @@ function ChannelDetector() {
                 ) continue;
                 context.result = null;
 
-                /*if (pattern === 'hue' && id.indexOf('yeelight-2.0.color-') !== -1) {
-                    console.log(pattern);
-                }*/
-
                 var _usedIds = [];
                 context.pattern = pattern;
                 context._usedIds = _usedIds;
                 patterns[pattern].states.forEach(function (state) {
                     var found = false;
-
-                    if (state.name === 'ON') {
-                        //console.log('ON');
-                    }
 
                     // one of following
                     if (state instanceof Array) {
@@ -1088,10 +1077,6 @@ function ChannelDetector() {
                     // context.result.id = id;
                     //this.cache[id] = context.result;
                     var deviceStates;
-
-                    if (pattern === 'info') {
-                        //console.log('AA');
-                    }
 
                     // looking for indicators and special states
                     if (objects[id].type !== 'device') {

--- a/index.js
+++ b/index.js
@@ -961,6 +961,25 @@ function ChannelDetector() {
         return found;
     };
 
+    this._getChannelStates = function (objects, id, keys) {
+      var result = [];
+
+      if (objects[id].type === 'state') {
+        result = [id];
+      } else if (objects[id].type === 'device') {
+        result = getAllStatesInDevice(keys, id);
+        // if no states, it may be device without channels
+        if (!result.length) {
+          result = getAllStatesInChannel(keys, id);
+        }
+      } else {
+        // channel
+        result = getAllStatesInChannel(keys, id);
+      }
+
+      return result;
+    };
+
     this._detectNext = function (options) {
         var objects           = options.objects;
         var id                = options.id;
@@ -976,19 +995,7 @@ function ChannelDetector() {
         }
 
         if (objects[id] && objects[id].common) {
-            var channelStates;
-
-            if (objects[id].type === 'state') {
-                channelStates = [id];
-            } else if (objects[id].type === 'device') {
-                channelStates = getAllStatesInDevice(keys, id);
-                // if no states, it may be device without channels
-                if (!channelStates.length) {
-                    channelStates = getAllStatesInChannel(keys, id);
-                }
-            } else { // channel
-                channelStates = getAllStatesInChannel(keys, id);
-            }
+            var channelStates = this._getChannelStates(objects, id, keys);
 
             /*if (id.indexOf('yeelight-2.0.color-') !== -1) {
                 console.log('aaa');

--- a/index.js
+++ b/index.js
@@ -981,6 +981,21 @@ function ChannelDetector() {
       }
     }
 
+    function patternIsAllowed(pattern, allowedTypes, excludedTypes) {
+      if (!pattern) {
+        return false;
+      }
+
+      if (allowedTypes && allowedTypes.indexOf(pattern.type) === -1) {
+        return false;
+      }
+      if (excludedTypes && excludedTypes.indexOf(pattern.type) !== -1) {
+        return false;
+      }
+
+      return true;
+    }
+
     function allRequiredStatesFound(context) {
       if (!context.result) {
         return false;
@@ -1014,8 +1029,6 @@ function ChannelDetector() {
         var keys              = options._keysOptional;
         var usedIds           = options._usedIdsOptional;
         var ignoreIndicators  = options.ignoreIndicators;
-        var allowedTypes      = options.allowedTypes;
-        var excludedTypes     = options.excludedTypes;
 
         if (!usedIds) {
             usedIds = [];
@@ -1034,10 +1047,16 @@ function ChannelDetector() {
         };
 
         for (var pattern in patterns) {
-            if (!patterns.hasOwnProperty(pattern) ||
-                (allowedTypes && allowedTypes.indexOf(patterns[pattern].type) === -1) ||
-                (excludedTypes && excludedTypes.indexOf(patterns[pattern].type) !== -1)
-            ) continue;
+            if (
+              !patternIsAllowed(
+                patterns[pattern],
+                options.allowedTypes,
+                options.excludedTypes
+              )
+            ) {
+              continue;
+            }
+
             context.result = null;
 
             var _usedIds = [];

--- a/index.js
+++ b/index.js
@@ -27,45 +27,55 @@
 'use strict';
 
 var Types = {
-    unknown: 'unknown',
+  unknown: 'unknown',
 
-    airCondition: 'airCondition',
-    blind: 'blind',
-    button: 'button',
-    buttonSensor: 'buttonSensor',
-    camera: 'camera',
-    url: 'url',
-    image: 'image',
-    dimmer: 'dimmer',
-    door: 'door',
-    fireAlarm: 'fireAlarm',
-    floodAlarm: 'floodAlarm',
-    gate: 'gate',
-    humidity: 'humidity',
-    info: 'info',
-    instance: 'instance',
-    light: 'light',
-    lock: 'lock',
-    location: 'location',
-    media: 'media',
-    motion: 'motion',
-    rgb: 'rgb',
-    ct: 'ct',
-    rgbSingle: 'rgbSingle',
-    hue: 'hue',
-    slider: 'slider',
-    socket: 'socket',
-    temperature: 'temperature',
-    thermostat: 'thermostat',
-    valve: 'valve',
-    volume: 'volume',
-    vacuumCleaner: 'vacuumCleaner',
-    volumeGroup: 'volumeGroup',
-    window: 'window',
-    windowTilt: 'windowTilt',
-    weatherCurrent: 'weatherCurrent',
-    weatherForecast: 'weatherForecast',
-    warning: 'warning'
+  airCondition: 'airCondition',
+  blind: 'blind',
+  button: 'button',
+  buttonSensor: 'buttonSensor',
+  camera: 'camera',
+  url: 'url',
+  image: 'image',
+  dimmer: 'dimmer',
+  door: 'door',
+  fireAlarm: 'fireAlarm',
+  floodAlarm: 'floodAlarm',
+  gate: 'gate',
+  humidity: 'humidity',
+  info: 'info',
+  instance: 'instance',
+  light: 'light',
+  lock: 'lock',
+  location: 'location',
+  media: 'media',
+  motion: 'motion',
+  rgb: 'rgb',
+  ct: 'ct',
+  rgbSingle: 'rgbSingle',
+  hue: 'hue',
+  slider: 'slider',
+  socket: 'socket',
+  temperature: 'temperature',
+  thermostat: 'thermostat',
+  valve: 'valve',
+  volume: 'volume',
+  vacuumCleaner: 'vacuumCleaner',
+  volumeGroup: 'volumeGroup',
+  window: 'window',
+  windowTilt: 'windowTilt',
+  weatherCurrent: 'weatherCurrent',
+  weatherForecast: 'weatherForecast',
+  warning: 'warning',
+};
+
+var SharedPatterns = {
+    Working:     {role: /^indicator\.working$/,                 indicator: true,                                            name: 'WORKING',            required: false, defaultRole: 'indicator.working'},
+    Unreachable: {role: /^indicator(\.maintenance)?\.unreach$/, indicator: true,  type: 'boolean',                          name: 'UNREACH',            required: false, defaultRole: 'indicator.maintenance.unreach'},
+    LowBattery:  {role: /^indicator(\.maintenance)?\.lowbat$|^indicator(\.maintenance)?\.battery/,  indicator: true,  type: 'boolean',  name: 'LOWBAT', required: false, defaultRole: 'indicator.maintenance.lowbat'},
+    Maintenance: {role: /^indicator\.maintenance$/,             indicator: true,  type: 'boolean',                          name: 'MAINTAIN',           required: false, defaultRole: 'indicator.maintenance'},
+    Error:       {role: /^indicator\.error$/,                   indicator: true,                                            name: 'ERROR',              required: false, defaultRole: 'indicator.error'},
+    Direction:   {role: /^indicator\.direction$/,               indicator: true,                                            name: 'DIRECTION',          required: false, defaultRole: 'indicator.direction'},
+    Reachable:   {role: /^indicator\.reachable$/,               indicator: true,  type: 'boolean',                          name: 'CONNECTED',          required: false, defaultRole: 'indicator.reachable', inverted: true}
 };
 
 // Description of flags
@@ -94,14 +104,6 @@ function ChannelDetector() {
     if (!(this instanceof ChannelDetector)) {
         return new ChannelDetector();
     }
-
-    var patternWorking   = {role: /^indicator\.working$/,                 indicator: true,                                            name: 'WORKING',            required: false, defaultRole: 'indicator.working'};
-    var patternUnreach   = {role: /^indicator(\.maintenance)?\.unreach$/, indicator: true,  type: 'boolean',                          name: 'UNREACH',            required: false, defaultRole: 'indicator.maintenance.unreach'};
-    var patternLowbat    = {role: /^indicator(\.maintenance)?\.lowbat$|^indicator(\.maintenance)?\.battery/,  indicator: true,  type: 'boolean',  name: 'LOWBAT', required: false, defaultRole: 'indicator.maintenance.lowbat'};
-    var patternMaintain  = {role: /^indicator\.maintenance$/,             indicator: true,  type: 'boolean',                          name: 'MAINTAIN',           required: false, defaultRole: 'indicator.maintenance'};
-    var patternError     = {role: /^indicator\.error$/,                   indicator: true,                                            name: 'ERROR',              required: false, defaultRole: 'indicator.error'};
-    var patternDirection = {role: /^indicator\.direction$/,               indicator: true,                                            name: 'DIRECTION',          required: false, defaultRole: 'indicator.direction'};
-    var patternReachable = {role: /^indicator\.reachable$/,               indicator: true,  type: 'boolean',                          name: 'CONNECTED',          required: false, defaultRole: 'indicator.reachable', inverted: true};
 
     var patterns = {
         mediaPlayer: {
@@ -136,10 +138,10 @@ function ChannelDetector() {
                 {role: /^media.mute?$/,                 indicator: false,                   type: 'boolean',                               write: true,       name: 'MUTE',           required: false, notSingle: true, noSubscribe: true,   defaultRole: 'media.mute'},
                 // Ignore following states of chromecast
                 {stateName: /\.paused$|\.playerState$/, indicator: false,                                                                                     name: 'IGNORE',         required: false, multiple: true,  noSubscribe: true},
-                patternReachable,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Reachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.media
         },
@@ -206,11 +208,11 @@ function ChannelDetector() {
                 {role: /^switch\.light$/,                                 indicator: false, type: 'boolean', write: true,           name: 'ON',            required: false,  defaultRole: 'switch.light'},
                 {role: /^switch$/,                                        indicator: false, type: 'boolean', write: true,           name: 'ON',            required: false,  defaultRole: 'switch.light'},
                 {role: /^state(\.light)?$/,                               indicator: false, type: 'boolean', write: false,          name: 'ON_ACTUAL',     required: false,  defaultRole: 'state.light'},
-                patternWorking,
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Working,
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.rgb
         },
@@ -226,11 +228,11 @@ function ChannelDetector() {
                 {role: /^level\.color\.temperature$/,                     indicator: false, type: 'number',  write: true,           name: 'TEMPERATURE',   required: false,  defaultUnit: '°K'},
                 {role: /^switch\.light$/,                                 indicator: false, type: 'boolean', write: true,           name: 'ON',            required: false,  defaultRole: 'switch.light'},
                 {role: /^switch$/,                                        indicator: false, type: 'boolean', write: true,           name: 'ON',            required: false},
-                patternWorking,
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Working,
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.rgb
         },
@@ -244,11 +246,11 @@ function ChannelDetector() {
                 {role: /^switch\.light$/,                                 indicator: false, type: 'boolean', write: true,           name: 'ON',            required: false,  defaultRole: 'switch.light'},
                 {role: /^switch$/,                                        indicator: false, type: 'boolean', write: true,           name: 'ON',            required: false,  defaultRole: 'switch.light'},
                 {role: /^state(\.light)?$/,                               indicator: false, type: 'boolean', write: false,          name: 'ON_ACTUAL',     required: false,  defaultRole: 'state.light'},
-                patternWorking,
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Working,
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.rgbSingle
         },
@@ -262,11 +264,11 @@ function ChannelDetector() {
                 {role: /^switch\.light$/,                                 indicator: false, type: 'boolean', write: true,           name: 'ON',            required: false, defaultRole: 'switch.light'},
                 {role: /^switch$/,                                        indicator: false, type: 'boolean', write: true,           name: 'ON',            required: false, defaultRole: 'switch.light'},
                 {role: /^state(\.light)?$/,                               indicator: false, type: 'boolean', write: false,          name: 'ON_ACTUAL',     required: false,  defaultRole: 'state.light'},
-                patternWorking,
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Working,
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.hue
         },
@@ -278,11 +280,11 @@ function ChannelDetector() {
                 {role: /^level\.color\.saturation$/,                      indicator: false, type: 'number',  write: true,           name: 'SATURATION',    required: false},
                 {role: /^switch\.light$/,                                 indicator: false, type: 'boolean', write: true,           name: 'ON',            required: false, defaultRole: 'switch.light'},
                 {role: /^switch$/,                                        indicator: false, type: 'boolean', write: true,           name: 'ON',            required: false, defaultRole: 'switch.light'},
-                patternWorking,
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Working,
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.ct
         },
@@ -316,9 +318,9 @@ function ChannelDetector() {
                 {role: /humidity(\..*)?$/,             indicator: false,     write: false, type: 'number',    searchInParent: true,                           name: 'HUMIDITY',           required: false, defaultRole: 'value.humidity',        defaultUnit: '%'},
                 {role: /^switch\.boost(\..*)?$/,       indicator: false,     write: true,  type: ['boolean', 'number'],   searchInParent: true,               name: 'BOOST',              required: false, defaultRole: 'switch.boost'},
                 {role: /swing$/,                       indicator: false,     write: true,  type: 'number',    searchInParent: true,                           name: 'SWING',              required: false, defaultRole: 'level.mode.swing',      defaultStates: {0: 'AUTO', 1: 'HORIZONTAL', 2: 'STATIONARY', 3: 'VERTICAL'}},
-                patternUnreach,
-                patternMaintain,
-                patternError
+                SharedPatterns.Unreachable,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.airCondition
         },
@@ -330,11 +332,11 @@ function ChannelDetector() {
                 {role: /humidity(\..*)?$/,             indicator: false,     write: false, type: 'number',    searchInParent: true,                           name: 'HUMIDITY',           required: false, defaultRole: 'value.humidity', defaultUnit: '%'},
                 {role: /^switch\.boost(\..*)?$/,       indicator: false,     write: true,  type: ['boolean', 'number'],   searchInParent: true,               name: 'BOOST',              required: false, defaultRole: 'switch.boost'},
                 {role: /^switch\.power$/,              indicator: false,     write: true,  type: ['boolean', 'number'],   searchInParent: true,               name: 'POWER',              required: false, defaultRole: 'switch.power'},
-                patternWorking,
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Working,
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.thermostat
         },
@@ -352,10 +354,10 @@ function ChannelDetector() {
                 {role: /^switch\.pause$/,              indicator: false,     write: true,  type: 'boolean',               searchInParent: true,               name: 'PAUSE',              required: false, defaultRole: 'switch.pause'},
                 {role: /^indicator(\.maintenance)?\.waste$|^indicator(\.alarm)?\.waste/,  indicator: true,  type: 'boolean',                                  name: 'WASTE_ALARM',        required: false, defaultRole: 'indicator.maintenance.waste'},
                 {role: /^indicator(\.maintenance)?\.water$|^indicator(\.alarm)?\.water/,  indicator: true,  type: 'boolean',                                  name: 'WATER_ALARM',        required: false, defaultRole: 'indicator.maintenance.water'},
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.vacuumCleaner
         },
@@ -365,12 +367,12 @@ function ChannelDetector() {
                 // optional
                 {role: /^value(\.blind)?$/,                   indicator: false, type: 'number',               enums: roleOrEnumBlind, name: 'ACTUAL',              required: false, defaultRole: 'value.blind', defaultUnit: '%'},
                 {role: /^button\.stop$|^action\.stop$/,       indicator: false, type: 'boolean', write: true, enums: roleOrEnumBlind, name: 'STOP',                required: false, noSubscribe: true, defaultRole: 'button.stop'},
-                patternDirection,
-                patternWorking,
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Direction,
+                SharedPatterns.Working,
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.blind
         },
@@ -380,12 +382,12 @@ function ChannelDetector() {
                 // optional
                 {role: /^state$/,                             indicator: false, type: 'boolean',  write: false,             name: 'ACTUAL',              required: false, defaultRole: 'state'},
                 {                                             indicator: false, type: 'boolean',  write: true, read: false, name: 'OPEN',                required: false, noSubscribe: true, defaultRole: 'button'},
-                patternDirection,
-                patternWorking,
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Direction,
+                SharedPatterns.Working,
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.lock
         },
@@ -394,10 +396,10 @@ function ChannelDetector() {
                 {role: /^state\.motion$|^sensor\.motion$/,                   indicator: false, type: 'boolean', name: 'ACTUAL',     required: true, defaultRole: 'sensor.motion'},
                 // optional
                 {role: /brightness$/,                                        indicator: false, type: 'number',  name: 'SECOND',     required: false, defaultRole: 'value.brightness'},
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.motion
         },
@@ -405,10 +407,10 @@ function ChannelDetector() {
             states: [
                 {role: /^state(\.window)?$|^sensor(\.window)?/,                   indicator: false, type: 'boolean', enums: roleOrEnumWindow, name: 'ACTUAL',     required: true, defaultRole: 'sensor.window'},
                 // optional
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.window
         },
@@ -416,10 +418,10 @@ function ChannelDetector() {
             states: [
                 {role: /^state?$|^value(\.window)?$/,                             indicator: false, type: 'number',  enums: roleOrEnumWindow, name: 'ACTUAL',     required: true, defaultRole: 'value.window'},
                 // optional
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.windowTilt
         },
@@ -427,10 +429,10 @@ function ChannelDetector() {
             states: [
                 {role: /^state?$|^sensor(\.alarm)?\.fire/,                        indicator: false, type: 'boolean', name: 'ACTUAL',     required: true, channelRole: /^sensor(\.alarm)?\.fire$/, defaultRole: 'sensor.alarm.fire'},
                 // optional
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.fireAlarm
         },
@@ -438,10 +440,10 @@ function ChannelDetector() {
             states: [
                 {role: /^state?$|^state(\.door)?$|^sensor(\.door)?/,              indicator: false, type: 'boolean', write: false, enums: roleOrEnumDoor, name: 'ACTUAL',     required: true, defaultRole: 'sensor.door'},
                 // optional
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.door
         },
@@ -452,11 +454,11 @@ function ChannelDetector() {
                 {role: /^value(\.dimmer)?$/,                   indicator: false, type: 'number',  write: false,      enums: roleOrEnumLight, name: 'ACTUAL',      required: false, defaultRole: 'value.dimmer', defaultUnit: '%'},
                 {role: /^switch(\.light)?$|^state$/,           indicator: false, type: 'boolean', write: true,       enums: roleOrEnumLight, name: 'ON_SET',      required: false, defaultRole: 'switch.light'},
                 {role: /^switch(\.light)?$|^state$/,           indicator: false, type: 'boolean', write: false,      enums: roleOrEnumLight, name: 'ON_ACTUAL',   required: false, defaultRole: 'switch.light'},
-                patternWorking,
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Working,
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.dimmer
         },
@@ -465,11 +467,11 @@ function ChannelDetector() {
                 {role: /^switch(\.light)?$|^state$/,           indicator: false, type: 'boolean', write: true,       enums: roleOrEnumLight, name: 'SET',         required: true,  defaultRole: 'switch.light'},
                 // optional
                 {role: /^switch(\.light)?$|^state$/,           indicator: false, type: 'boolean', write: false,      enums: roleOrEnumLight, name: 'ACTUAL',      required: false, defaultRole: 'switch.light'},
-                patternWorking,
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Working,
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.light
         },
@@ -479,11 +481,11 @@ function ChannelDetector() {
                 // optional
                 {role: /^value\.volume$/,                   indicator: false, type: 'number',  min: 'number', max: 'number', write: false,      name: 'ACTUAL',      required: false,  defaultRole: 'value.volume'},
                 {role: /^media\.mute$/,                     indicator: false, type: 'boolean',                               write: true,       name: 'MUTE',        required: false,  defaultRole: 'media.mute'},
-                patternWorking,
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Working,
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.volume
         },
@@ -494,10 +496,10 @@ function ChannelDetector() {
                 {role: /^value\.gps\.elevation$/,                  indicator: false, type: 'number',  write: false,      name: 'ELEVATION',     required: false,  defaultRole: 'value.gps.elevation'},
                 {role: /^value\.radius$|value\.gps\.radius$/,      indicator: false, type: 'number',  write: false,      name: 'RADIUS',        required: false,  defaultRole: 'value.gps.radius'},
                 {role: /^value\.accuracy$|^value\.gps\.accuracy$/, indicator: false, type: 'number',  write: false,      name: 'ACCURACY',      required: false,  defaultRole: 'value.gps.accuracy'},
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.location
         },
@@ -509,10 +511,10 @@ function ChannelDetector() {
                 {role: /^value\.gps\.elevation$/,                  indicator: false, type: 'number',  write: false,      name: 'ELEVATION',     required: false,  defaultRole: 'value.gps.elevation'},
                 {role: /^value\.radius$|value\.gps\.radius$/,      indicator: false, type: 'number',  write: false,      name: 'RADIUS',        required: false,  defaultRole: 'value.gps.radius'},
                 {role: /^value\.accuracy$|^value\.gps\.accuracy$/, indicator: false, type: 'number',  write: false,      name: 'ACCURACY',      required: false,  defaultRole: 'value.gps.accuracy'},
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.location
         },
@@ -521,11 +523,11 @@ function ChannelDetector() {
                 {role: /^level\.volume\.group?$/,            indicator: false, type: 'number',  min: 'number', max: 'number', write: true,       name: 'SET',         required: true,  defaultRole: 'level.volume.group'},
                 {role: /^value\.volume\.group$/,             indicator: false, type: 'number',  min: 'number', max: 'number', write: false,      name: 'ACTUAL',      required: false, defaultRole: 'value.volume.group'},
                 {role: /^media\.mute\.group$/,               indicator: false, type: 'boolean',                               write: true,       name: 'MUTE',        required: false, defaultRole: 'media.mute.group'},
-                patternWorking,
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Working,
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.volumeGroup
         },
@@ -533,11 +535,11 @@ function ChannelDetector() {
             states: [
                 {role: /^level(\..*)?$/,                   indicator: false, type: 'number',  min: 'number', max: 'number', write: true,       name: 'SET',         required: true, defaultRole: 'level', defaultUnit: '%'},
                 {role: /^value(\..*)?$/,                   indicator: false, type: 'number',  min: 'number', max: 'number', write: false,      name: 'ACTUAL',      required: false, defaultRole: 'value'},
-                patternWorking,
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Working,
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.slider
         },
@@ -545,21 +547,21 @@ function ChannelDetector() {
             states: [
                 {role: /^switch$|^state$|^switch\.active$/,           indicator: false, type: 'boolean', write: true,       name: 'SET',         required: true, defaultRole: 'switch'},
                 {role: /^state$|^state\.active$/,                     indicator: false, type: 'boolean', write: false,      name: 'ACTUAL',      required: false, defaultRole: 'switch'},
-                patternWorking,
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Working,
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.socket
         },
         button: {
             states: [
                 {role: /^button(\.[.\w]+)?$|^action(\.[.\w]+)?$/,           indicator: false, type: 'boolean', read: false, write: true,       name: 'SET',         required: true, noSubscribe: true, defaultRole: 'button'},
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.button
         },
@@ -568,10 +570,10 @@ function ChannelDetector() {
                 {role: /^button(\.[.\w]+)?$/,           indicator: false, type: 'boolean', read: true, write: false,       name: 'PRESS',         required: true,  defaultRole: 'button.press'},
                 // optional
                 {role: /^button\.long/,                 indicator: false, type: 'boolean', read: true, write: false,       name: 'PRESS_LONG',    required: false, defaultRole: 'button.long'},
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.buttonSensor
         },
@@ -579,41 +581,41 @@ function ChannelDetector() {
             states: [
                 {role: /temperature$/,             indicator: false, write: false, type: 'number',  name: 'ACTUAL',     required: true,  defaultRole: 'value.temperature', defaultUnit: '°C'},
                 {role: /humidity$/,                indicator: false, write: false, type: 'number',  name: 'SECOND',     required: false, defaultRole: 'value.humidity', defaultUnit: '%'},
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.temperature
         },
         humidity: {
             states: [
                 {role: /humidity$/,                indicator: false, write: false, type: 'number',  name: 'ACTUAL',     required: true, defaultRole: 'value.humidity', defaultUnit: '%'},
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.humidity
         },
         image: {
             states: [
                 {role: /\.icon$|^icon$|^icon\.|\.icon\.|\.chart\.url\.|\.chart\.url$|^url.icon$/, indicator: false, write: false, type: 'string', name: 'URL', required: true},
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.image
         },
         info: {
             states: [
                 {                                  indicator: false,                                 name: 'ACTUAL',         required: true, multiple: true, noDeviceDetection: true, ignoreRole: /\.inhibit$/, defaultRole: 'state'},
-                patternWorking,
-                patternUnreach,
-                patternLowbat,
-                patternMaintain,
-                patternError
+                SharedPatterns.Working,
+                SharedPatterns.Unreachable,
+                SharedPatterns.LowBattery,
+                SharedPatterns.Maintenance,
+                SharedPatterns.Error
             ],
             type: Types.info
         }

--- a/index.js
+++ b/index.js
@@ -1071,72 +1071,74 @@ function ChannelDetector() {
                 }
             }.bind(this));
 
-            if (allRequiredStatesFound(context)) {
-              _usedIds.forEach(function (id) {
-                usedIds.push(id);
-              });
-              // context.result.id = id;
-              //this.cache[id] = context.result;
-              var deviceStates;
-
-              // looking for indicators and special states
-              if (objects[id].type !== 'device') {
-                // get device name
-                var deviceId = getParentId(id);
-                if (
-                  objects[deviceId] &&
-                  (objects[deviceId].type === 'channel' ||
-                    objects[deviceId].type === 'device')
-                ) {
-                  deviceStates = getAllStatesInDevice(keys, deviceId);
-                  if (deviceStates) {
-                    deviceStates.forEach(
-                      function (_id) {
-                        context.result.states.forEach(
-                          function (state, i) {
-                            if (
-                              !state.id &&
-                              (state.indicator || state.searchInParent) &&
-                              !state.noDeviceDetection
-                            ) {
-                              if (
-                                this._applyPattern(objects, _id, state.original)
-                              ) {
-                                context.result.states[i].id = _id;
-                              }
-                            }
-                          }.bind(this),
-                        );
-                      }.bind(this),
-                    );
-                  }
-                }
-              }
-              context.result.states.forEach(function (state) {
-                if (state.name.indexOf('%d') !== -1 && state.role && state.id) {
-                  var m = state.role.exec(
-                    context.objects[state.id].common.role,
-                  );
-                  if (m) {
-                    state.name = state.name.replace('%d', m[1]);
-                  }
-                }
-                if (state.role) {
-                  delete state.role;
-                }
-                if (state.enums) {
-                  delete state.enums;
-                }
-                if (state.original) {
-                  if (state.original.icon) {
-                    state.icon = state.original.icon;
-                  }
-                  delete state.original;
-                }
-              });
-
-              return context.result;
+            if (!allRequiredStatesFound(context)) {
+                continue;
             }
+
+            _usedIds.forEach(function (id) {
+            usedIds.push(id);
+            });
+            // context.result.id = id;
+            //this.cache[id] = context.result;
+            var deviceStates;
+
+            // looking for indicators and special states
+            if (objects[id].type !== 'device') {
+            // get device name
+            var deviceId = getParentId(id);
+            if (
+                objects[deviceId] &&
+                (objects[deviceId].type === 'channel' ||
+                objects[deviceId].type === 'device')
+            ) {
+                deviceStates = getAllStatesInDevice(keys, deviceId);
+                if (deviceStates) {
+                deviceStates.forEach(
+                    function (_id) {
+                    context.result.states.forEach(
+                        function (state, i) {
+                        if (
+                            !state.id &&
+                            (state.indicator || state.searchInParent) &&
+                            !state.noDeviceDetection
+                        ) {
+                            if (
+                            this._applyPattern(objects, _id, state.original)
+                            ) {
+                            context.result.states[i].id = _id;
+                            }
+                        }
+                        }.bind(this),
+                    );
+                    }.bind(this),
+                );
+                }
+            }
+            }
+            context.result.states.forEach(function (state) {
+            if (state.name.indexOf('%d') !== -1 && state.role && state.id) {
+                var m = state.role.exec(
+                context.objects[state.id].common.role,
+                );
+                if (m) {
+                state.name = state.name.replace('%d', m[1]);
+                }
+            }
+            if (state.role) {
+                delete state.role;
+            }
+            if (state.enums) {
+                delete state.enums;
+            }
+            if (state.original) {
+                if (state.original.icon) {
+                state.icon = state.original.icon;
+                }
+                delete state.original;
+            }
+            });
+
+            return context.result;
         }
     };
 

--- a/index.js
+++ b/index.js
@@ -979,7 +979,42 @@ function ChannelDetector() {
           // channel
           return getAllStatesInChannel(keys, id);
       }
-    };
+    }
+
+    function allRequiredStatesFound(){
+        var allRequiredFound = true;
+        if (context.result) {
+          for (var a = 0; a < context.result.states.length; a++) {
+            if (context.result.states[a] instanceof Array) {
+              // one of
+              var oneOf = false;
+              for (var b = 0; b < context.result.states[a].length; b++) {
+                if (
+                  context.result.states[a][b].required &&
+                  context.result.states[a].id
+                ) {
+                  oneOf = true;
+                  break;
+                }
+              }
+              if (!oneOf) {
+                allRequiredFound = false;
+                break;
+              }
+            } else {
+              if (
+                context.result.states[a].required &&
+                !context.result.states[a].id
+              ) {
+                allRequiredFound = false;
+                break;
+              }
+            }
+          }
+        } else {
+          allRequiredFound = false;
+        }
+    }
 
     this._detectNext = function (options) {
         var objects           = options.objects;
@@ -1044,36 +1079,7 @@ function ChannelDetector() {
                 }
             }.bind(this));
 
-            // if all required states found?
-            var allRequiredFound = true;
-            if (context.result) {
-                for (var a = 0; a < context.result.states.length; a++) {
-                    if (context.result.states[a] instanceof Array) {
-                        // one of
-                        var oneOf = false;
-                        for (var b = 0; b < context.result.states[a].length; b++) {
-                            if (context.result.states[a][b].required && context.result.states[a].id) {
-                                oneOf = true;
-                                break;
-                            }
-                        }
-                        if (!oneOf) {
-                            allRequiredFound = false;
-                            break;
-                        }
-                    } else {
-                        if (context.result.states[a].required && !context.result.states[a].id) {
-                            allRequiredFound = false;
-                            break;
-                        }
-                    }
-                }
-            } else {
-                allRequiredFound = false;
-            }
-
-
-            if (allRequiredFound) {
+            if (allRequiredStatesFound()) {
                 _usedIds.forEach(function (id) {usedIds.push(id);});
                 // context.result.id = id;
                 //this.cache[id] = context.result;

--- a/index.js
+++ b/index.js
@@ -961,7 +961,7 @@ function ChannelDetector() {
         return found;
     };
 
-    this._getChannelStates = function (objects, id, keys) {
+    function getChannelStates(objects, id, keys) {
       switch (objects[id].type) {
         case 'state':
           return [id];
@@ -1001,7 +1001,7 @@ function ChannelDetector() {
 
         var context = {
             objects:            objects,
-            channelStates:      this._getChannelStates(objects, id, keys),
+            channelStates:      getChannelStates(objects, id, keys),
             usedIds:            usedIds,
             ignoreIndicators:   ignoreIndicators
         };

--- a/index.js
+++ b/index.js
@@ -962,22 +962,23 @@ function ChannelDetector() {
     };
 
     this._getChannelStates = function (objects, id, keys) {
-      var result = [];
+      switch (objects[id].type) {
+        case 'state':
+          return [id];
 
-      if (objects[id].type === 'state') {
-        result = [id];
-      } else if (objects[id].type === 'device') {
-        result = getAllStatesInDevice(keys, id);
-        // if no states, it may be device without channels
-        if (!result.length) {
-          result = getAllStatesInChannel(keys, id);
-        }
-      } else {
-        // channel
-        result = getAllStatesInChannel(keys, id);
+        case 'device':
+          var result = getAllStatesInDevice(keys, id);
+          if (result.length) {
+            return result;
+          }
+
+          // if no states, it may be device without channels
+          return getAllStatesInChannel(keys, id);
+
+        default:
+          // channel
+          return getAllStatesInChannel(keys, id);
       }
-
-      return result;
     };
 
     this._detectNext = function (options) {

--- a/index.js
+++ b/index.js
@@ -996,11 +996,9 @@ function ChannelDetector() {
         }
 
         if (objects[id] && objects[id].common) {
-            var channelStates = this._getChannelStates(objects, id, keys);
-
             var context = {
                 objects:            objects,
-                channelStates:      channelStates,
+                channelStates:      this._getChannelStates(objects, id, keys),
                 usedIds:            usedIds,
                 ignoreIndicators:   ignoreIndicators
             };

--- a/index.js
+++ b/index.js
@@ -1164,14 +1164,13 @@ function ChannelDetector() {
             options._keysOptional = _keysOptional;
         }
 
-        var result  = [];
         if (_usedIdsOptional) {
             _usedIdsOptional = [];
             options._usedIdsOptional = _usedIdsOptional;
         }
 
+        var result = [];
         var detected;
-
         while((detected = this._detectNext(options))) {
             result.push(detected);
         }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "main": "main.js",
   "scripts": {
-    "test": "node node_modules/mocha/bin/mocha --exit"
+    "test": "node node_modules/mocha/bin/mocha --exit",
+    "watch": "node node_modules/mocha/bin/mocha --watch"
   },
   "license": "MIT",
   "readmeFilename": "README.md"

--- a/test/detector.test.js
+++ b/test/detector.test.js
@@ -3,6 +3,45 @@ var expect = require('chai').expect;
 const {Types, ChannelDetector} = require('../index');
 
 describe('Test Detector', () => {
+    it('Must detect nothing if not all required states are defined', done => {
+      const detector = new ChannelDetector();
+
+      const objects = {
+        'something.0.channel': {
+          common: {
+            name: 'Channel',
+          },
+          type: 'channel',
+        },
+        'something.0.channel.state': {
+          common: {
+            name: 'Some state',
+            type: 'some-type',
+            role: 'some-role.inhibit',
+            read: false,
+            write: false,
+          },
+          type: 'state',
+        },
+      };
+
+      Object.keys(objects).forEach(id => (objects[id]._id = id));
+
+      const options = {
+        objects: objects,
+        id: 'something.0.channel',
+        _keysOptional: Object.keys(objects),
+        _usedIdsOptional: [],
+      };
+
+      const controls = detector.detect(options);
+
+      console.log(JSON.stringify(controls));
+      expect(controls).to.be.null;
+
+      done();
+    });
+
     it('Must detect temperature sensor from channel', done => {
         const detector = new ChannelDetector();
 


### PR DESCRIPTION
Hello,

I was thinking about sending an e-mail, but let's try this in public. During the last days, I was trying to get iobroker.lovelace to detect my HmIP-BBL shutters. This didn't work because of reasons found in the Lovelace adapter, but also because of this one here. First I needed to understand that this lib is used to make Lovelace understand ioBroker's states. 

My next question was how ioBroker's states should look like in order to be found/understood by Lovelace. For that, you have the [`Types` variable](https://github.com/ioBroker/ioBroker.type-detector/blob/027b3f503e834d97b8e720cb9ce968e92eb598cd/index.js#L29), which is kind-of readable. But it also has some quirks, IMHO. Like having "one-of" arrays for states that make stuff required despite the array elements not being `required: true`. As someone who doesn't maintain the type detector, this is rather hard to understand.

But the main reason for this PR is that it is virtually not possible to determine why ioBroker states do _not_ end up being detected as blinds/shutters, media players, etc. At least these were the examples I tried: create some channel/state structure inside `alias.0` and see if Lovelace displays new entities to add to the UI. I failed at both shutters and media players.

To understand what was going on I added lots of logging to ioBroker.lovelace. I found that it didn't receive blinds or media player controls from this library, so I dug here. Please understand that as someone who didn't write this code it is a bit hard to understand. It's not well documented. There are almost no tests. For the media player alias structure, I was able to [write a unit test that succeeded](https://github.com/ioBroker/ioBroker.lovelace/issues/106#issuecomment-691672827). But when I replicated a similar structure in ioBroker there was again no media player control passed to Lovelace.

My main points are:

* As someone that has written code before but didn't maintain this project, the code is hard to understand
* There is absolutely no way to log the things iobroker.type-detector does in production, most importantly *why it won't accept states as some type*
* I believe there are lots of low-hanging fruits w.r.t. refactoring. If you follow my commit log you see that by extracting `function`s and inverting `if`s the code can be flattened and made much more readable.
* I do not know the ins and outs of this adapter, so I will likely ask for help

This is why I started changing the code *structure* (i.e. not the semantics, hopefully) and opened this PR. It's not finished yet, but before I invest a lot of time I wanted to ask whether you are even interested in it. I believe the code that is the foundation for Lovelace and other adapters should be written in such a way that adapter authors can understand how it works and how the states are supposed to look like without much head-scratching.

Please let me know what you think. Thank you for listening.

Alex