### PR TITLE
add weatherForecast tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ function ChannelDetector() {
             ],
             type: Types.media
         },
-        weatherForecast : {
+        weatherForecast: {
             states: [
                 {role: /^weather.icon$|^weather.icon.forecast.0$/,                   indicator: false, type: 'string',  name: 'ICON',          required: true, defaultRole: 'weather.icon.forecast.0'},
                 {role: /^value.temperature.min.forecast.0$/,                         indicator: false, type: 'number',  name: 'TEMP_MIN',      required: true, defaultRole: 'value.temperature.min.forecast.0'},

--- a/test/detector.test.js
+++ b/test/detector.test.js
@@ -2,6 +2,15 @@ var expect = require('chai').expect;
 
 const {Types, ChannelDetector} = require('../index');
 
+function expectStateToHaveId(states, name, id, alternativeId) {
+    const control = states.find(s => s.name === name);
+    expect(control).to.be.ok;
+    expect(control).to.have.property('id');
+    if (control.id !== id && control.id !== alternativeId) {
+        expect(control.id).to.be.equal(id);
+    }
+}
+
 describe('Test Detector', () => {
     it('Must detect temperature sensor from channel', done => {
         const detector = new ChannelDetector();
@@ -325,4 +334,127 @@ describe('Test Detector', () => {
 
         done();
     });
+
+    it('Must detect forecast from accuweather and assign days correctly', done => {
+        const detector = new ChannelDetector();
+
+        const objects = require('./weather_accuweather.json');
+        Object.keys(objects).forEach(id => objects[id]._id = id);
+
+        const options = {
+            objects,
+            id:                 Object.keys(objects)[0],
+            _keysOptional:      Object.keys(objects),
+            _usedIdsOptional:   []
+        };
+
+        const controls = detector.detect(options);
+        console.dir(controls, { depth: null});
+        expect(controls[0].type).to.be.equal(Types.weatherForecast);
+        const expectMyStateToHaveId = expectStateToHaveId.bind(null, controls[0].states);
+        expectMyStateToHaveId('ICON', 'accuweather.0.Summary.WeatherIconURL_d1', 'accuweather.0.Summary.WeatherIconURL');
+        expectMyStateToHaveId('TEMP', 'accuweather.0.Summary.Temperature');
+        expectMyStateToHaveId('DATE', 'accuweather.0.Summary.DateTime_d1', 'accuweather.0.Summary.Date');
+        expectMyStateToHaveId('FEELS_LIKE', 'accuweather.0.Summary.RealFeelTemperature');
+        expectMyStateToHaveId('WIND_SPEED', 'accuweather.0.Summary.WindSpeed_d1', 'accuweather.0.Summary.WindSpeed');
+        expectMyStateToHaveId('WIND_DIRECTION', 'accuweather.0.Summary.WindDirection', 'accuweather.0.Summary.WindDirection_d1');
+        expectMyStateToHaveId('WIND_DIRECTION_STR', 'accuweather.0.Summary.WindDirectionStr', 'accuweather.0.Summary.WindDirectionStr_d1');
+        expectMyStateToHaveId('HUMIDITY', 'accuweather.0.Summary.RelativeHumidity');
+        expectMyStateToHaveId('PRESSURE', 'accuweather.0.Summary.Pressure');
+        expectMyStateToHaveId('DOW', 'accuweather.0.Summary.DayOfWeek', 'accuweather.0.Summary.DayOfWeek_d1');
+        expectMyStateToHaveId('TEMP_MIN', 'accuweather.0.Summary.TempMin_d1');
+        expectMyStateToHaveId('TEMP_MAX', 'accuweather.0.Summary.TempMax_d1');
+
+        const days = [1, 2, 3, 4]
+        for (const day of days) {
+            expectMyStateToHaveId(`DATE${day}`, `accuweather.0.Summary.DateTime_d${day + 1}`);
+            expectMyStateToHaveId(`ICON${day}`, `accuweather.0.Summary.WeatherIconURL_d${day + 1}`);
+            expectMyStateToHaveId(`STATE${day}`, `accuweather.0.Summary.WeatherText_d${day + 1}`);
+            expectMyStateToHaveId(`TEMP_MIN${day}`, `accuweather.0.Summary.TempMin_d${day + 1}`);
+            expectMyStateToHaveId(`TEMP_MAX${day}`, `accuweather.0.Summary.TempMax_d${day + 1}`);
+            expectMyStateToHaveId(`WIND_SPEED${day}`, `accuweather.0.Summary.WindSpeed_d${day + 1}`);
+            expectMyStateToHaveId(`WIND_DIRECTION${day}`, `accuweather.0.Summary.WindDirection_d${day + 1}`);
+            expectMyStateToHaveId(`WIND_DIRECTION_STR${day}`, `accuweather.0.Summary.WindDirectionStr_d${day + 1}`);
+            expectMyStateToHaveId(`DOW${day}`, `accuweather.0.Summary.DayOfWeek_d${day + 1}`);
+            expectMyStateToHaveId(`PRECIPITATION_CHANCE${day}`, `accuweather.0.Summary.PrecipitationProbability_d${day + 1}`);
+            expectMyStateToHaveId(`PRECIPITATION${day}`, `accuweather.0.Summary.TotalLiquidVolume_d${day + 1}`);
+        }
+        done();
+    });
+
+    it('Must detect forecast from dasWetter and assign days correctly', done => {
+        const detector = new ChannelDetector();
+
+        const objects = require('./weather_daswetter.json');
+        Object.keys(objects).forEach(id => objects[id]._id = id);
+
+        const options = {
+            objects,
+            id:                 Object.keys(objects)[0],
+            _keysOptional:      Object.keys(objects),
+            _usedIdsOptional:   []
+        };
+
+        const controls = detector.detect(options);
+        console.dir(controls, { depth: null});
+        expect(controls[0].type).to.be.equal(Types.weatherForecast);
+        const expectMyStateToHaveId = expectStateToHaveId.bind(null, controls[0].states);
+        expectMyStateToHaveId('ICON', 'daswetter.0.NextDays.Location_1.Day_1.iconURL');
+        expectMyStateToHaveId('TEMP_MIN', 'daswetter.0.NextDays.Location_1.Day_1.Minimale_Temperatur_value');
+        expectMyStateToHaveId('TEMP_MAX', 'daswetter.0.NextDays.Location_1.Day_1.Maximale_Temperatur_value');
+
+
+        const days = [1, 2, 3, 4, 5, 6];
+        for (const day of days) {
+            expectMyStateToHaveId(`ICON${day}`, `daswetter.0.NextDays.Location_1.Day_${day+1}.iconURL`);
+            expectMyStateToHaveId(`TEMP_MIN${day}`, `daswetter.0.NextDays.Location_1.Day_${day+1}.Minimale_Temperatur_value`);
+            expectMyStateToHaveId(`TEMP_MAX${day}`, `daswetter.0.NextDays.Location_1.Day_${day+1}.Maximale_Temperatur_value`);
+            expectMyStateToHaveId(`DOW${day}`, `daswetter.0.NextDays.Location_1.Day_${day+1}.Tag_value`);
+        }
+        done();
+    });
+
+    it('Must detect forecast from weatherunderground and assign days correctly', done => {
+        const detector = new ChannelDetector();
+
+        const objects = require('./weather_weatherunderground.json');
+        Object.keys(objects).forEach(id => objects[id]._id = id);
+
+        const options = {
+            objects,
+            id:                 Object.keys(objects)[0],
+            _keysOptional:      Object.keys(objects),
+            _usedIdsOptional:   []
+        };
+
+        const controls = detector.detect(options);
+        console.dir(controls, { depth: null});
+        for (const types of controls) {
+            console.log('Found ' + types.type);
+        }
+        expect(controls[0].type).to.be.equal(Types.weatherForecast);
+        const expectMyStateToHaveId = expectStateToHaveId.bind(null, controls[0].states);
+        expectMyStateToHaveId('ICON', 'weatherunderground.0.forecast.0d.iconURL');
+        expectMyStateToHaveId('TEMP', 'weatherunderground.0.forecast.current.temp');
+        expectMyStateToHaveId('TEMP_MIN', 'weatherunderground.0.forecast.0d.tempMin');
+        expectMyStateToHaveId('TEMP_MAX', 'weatherunderground.0.forecast.0d.tempMax');
+        expectMyStateToHaveId('PRECIPITATION_CHANCE', 'weatherunderground.0.forecast.0d.precipitationChance');
+        expectMyStateToHaveId('DATE', 'weatherunderground.0.forecast.current.observationTime');
+        expectMyStateToHaveId('STATE', 'weatherunderground.0.forecast.current.weather');
+        expectMyStateToHaveId('PRESSURE', 'weatherunderground.0.forecast.current.pressure');
+        expectMyStateToHaveId('HUMIDITY', 'weatherunderground.0.forecast.current.relativeHumidity');
+        expectMyStateToHaveId('WIND_CHILL', 'weatherunderground.0.forecast.current.windChill');
+        expectMyStateToHaveId('WIND_CHILL', 'weatherunderground.0.forecast.current.windChill');
+
+        const days = [1, 2, 3];
+        for (const day of days) {
+            expectMyStateToHaveId(`ICON${day}`, `weatherunderground.0.forecast.${day}d.iconURL`);
+            expectMyStateToHaveId(`TEMP_MIN${day}`, `weatherunderground.0.forecast.${day}d.tempMin`);
+            expectMyStateToHaveId(`TEMP_MAX${day}`, `weatherunderground.0.forecast.${day}d.tempMax`);
+            expectMyStateToHaveId(`DATE${day}`, `weatherunderground.0.forecast.${day}d.date`);
+        }
+
+        done();
+    });
 });
+

--- a/test/weather_accuweather.json
+++ b/test/weather_accuweather.json
@@ -1,0 +1,1173 @@
+{
+  "accuweather.0.Summary": {
+    "type": "channel",
+    "common": {
+      "name": "Weather Summary"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222154033,
+    "_id": "accuweather.0.Summary"
+  },
+  "accuweather.0.Summary.CurrentDateTime": {
+    "type": "state",
+    "common": {
+      "name": "Forecast date",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "date.forecast.0"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155034,
+    "_id": "accuweather.0.Summary.CurrentDateTime"
+  },
+  "accuweather.0.Summary.DateTime_d1": {
+    "type": "state",
+    "common": {
+      "name": "Forecast date day 1",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "date.forecast.0"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155036,
+    "_id": "accuweather.0.Summary.DateTime_d1"
+  },
+  "accuweather.0.Summary.DateTime_d2": {
+    "type": "state",
+    "common": {
+      "name": "Forecast date day 2",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "date.forecast.1"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155037,
+    "_id": "accuweather.0.Summary.DateTime_d2"
+  },
+  "accuweather.0.Summary.DateTime_d3": {
+    "type": "state",
+    "common": {
+      "name": "Forecast date day 3",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "date.forecast.2"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155038,
+    "_id": "accuweather.0.Summary.DateTime_d3"
+  },
+  "accuweather.0.Summary.DateTime_d4": {
+    "type": "state",
+    "common": {
+      "name": "Forecast date day 4",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "date.forecast.3"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155039,
+    "_id": "accuweather.0.Summary.DateTime_d4"
+  },
+  "accuweather.0.Summary.DateTime_d5": {
+    "type": "state",
+    "common": {
+      "name": "Forecast date day 5",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "date.forecast.4"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155040,
+    "_id": "accuweather.0.Summary.DateTime_d5"
+  },
+  "accuweather.0.Summary.DayOfWeek": {
+    "type": "state",
+    "common": {
+      "name": "Day of week",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "dayofweek.forecast.0",
+      "unit": ""
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155035,
+    "_id": "accuweather.0.Summary.DayOfWeek"
+  },
+  "accuweather.0.Summary.DayOfWeek_d1": {
+    "type": "state",
+    "common": {
+      "name": "Day of week day 1",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "dayofweek.forecast.0",
+      "unit": ""
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155037,
+    "_id": "accuweather.0.Summary.DayOfWeek_d1"
+  },
+  "accuweather.0.Summary.DayOfWeek_d2": {
+    "type": "state",
+    "common": {
+      "name": "Day of week day 2",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "dayofweek.forecast.1",
+      "unit": ""
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155038,
+    "_id": "accuweather.0.Summary.DayOfWeek_d2"
+  },
+  "accuweather.0.Summary.DayOfWeek_d3": {
+    "type": "state",
+    "common": {
+      "name": "Day of week day 3",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "dayofweek.forecast.2",
+      "unit": ""
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155039,
+    "_id": "accuweather.0.Summary.DayOfWeek_d3"
+  },
+  "accuweather.0.Summary.DayOfWeek_d4": {
+    "type": "state",
+    "common": {
+      "name": "Day of week day 4",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "dayofweek.forecast.3",
+      "unit": ""
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155040,
+    "_id": "accuweather.0.Summary.DayOfWeek_d4"
+  },
+  "accuweather.0.Summary.DayOfWeek_d5": {
+    "type": "state",
+    "common": {
+      "name": "Day of week day 5",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "dayofweek.forecast.4",
+      "unit": ""
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155041,
+    "_id": "accuweather.0.Summary.DayOfWeek_d5"
+  },
+  "accuweather.0.Summary.PrecipitationProbability_d1": {
+    "type": "state",
+    "common": {
+      "name": "Precipitation Probability day 1",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.precipitation.forecast.0",
+      "unit": "%"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155037,
+    "_id": "accuweather.0.Summary.PrecipitationProbability_d1"
+  },
+  "accuweather.0.Summary.PrecipitationProbability_d2": {
+    "type": "state",
+    "common": {
+      "name": "Precipitation Probability day 2",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.precipitation.forecast.1",
+      "unit": "%"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155038,
+    "_id": "accuweather.0.Summary.PrecipitationProbability_d2"
+  },
+  "accuweather.0.Summary.PrecipitationProbability_d3": {
+    "type": "state",
+    "common": {
+      "name": "Precipitation Probability day 3",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.precipitation.forecast.2",
+      "unit": "%"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155039,
+    "_id": "accuweather.0.Summary.PrecipitationProbability_d3"
+  },
+  "accuweather.0.Summary.PrecipitationProbability_d4": {
+    "type": "state",
+    "common": {
+      "name": "Precipitation Probability day 4",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.precipitation.forecast.3",
+      "unit": "%"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155040,
+    "_id": "accuweather.0.Summary.PrecipitationProbability_d4"
+  },
+  "accuweather.0.Summary.PrecipitationProbability_d5": {
+    "type": "state",
+    "common": {
+      "name": "Precipitation Probability day 5",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.precipitation.forecast.4",
+      "unit": "%"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155041,
+    "_id": "accuweather.0.Summary.PrecipitationProbability_d5"
+  },
+  "accuweather.0.Summary.Pressure": {
+    "type": "state",
+    "common": {
+      "name": "Pressure",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.pressure",
+      "unit": "mmHg"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155035,
+    "_id": "accuweather.0.Summary.Pressure"
+  },
+  "accuweather.0.Summary.RealFeelTemperature": {
+    "type": "state",
+    "common": {
+      "name": "Feels Like Temperature",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.temperature.feelslike.forecast.0",
+      "unit": "°C"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155035,
+    "_id": "accuweather.0.Summary.RealFeelTemperature"
+  },
+  "accuweather.0.Summary.RelativeHumidity": {
+    "type": "state",
+    "common": {
+      "name": "Humidity",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.humidity.forecast.0",
+      "unit": "%"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155035,
+    "_id": "accuweather.0.Summary.RelativeHumidity"
+  },
+  "accuweather.0.Summary.Sunrise": {
+    "type": "state",
+    "common": {
+      "name": "Sunrise time",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "time.sunrise",
+      "unit": ""
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155036,
+    "_id": "accuweather.0.Summary.Sunrise"
+  },
+  "accuweather.0.Summary.Sunset": {
+    "type": "state",
+    "common": {
+      "name": "Sunset time",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "time.sunset",
+      "unit": ""
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155036,
+    "_id": "accuweather.0.Summary.Sunset"
+  },
+  "accuweather.0.Summary.TempMax_d1": {
+    "type": "state",
+    "common": {
+      "name": "Max Temperature day 1",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.temperature.max.forecast.0",
+      "unit": "°C"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155036,
+    "_id": "accuweather.0.Summary.TempMax_d1"
+  },
+  "accuweather.0.Summary.TempMax_d2": {
+    "type": "state",
+    "common": {
+      "name": "Max Temperature day 2",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.temperature.max.forecast.1",
+      "unit": "°C"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155037,
+    "_id": "accuweather.0.Summary.TempMax_d2"
+  },
+  "accuweather.0.Summary.TempMax_d3": {
+    "type": "state",
+    "common": {
+      "name": "Max Temperature day 3",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.temperature.max.forecast.2",
+      "unit": "°C"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155039,
+    "_id": "accuweather.0.Summary.TempMax_d3"
+  },
+  "accuweather.0.Summary.TempMax_d4": {
+    "type": "state",
+    "common": {
+      "name": "Max Temperature day 4",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.temperature.max.forecast.3",
+      "unit": "°C"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155040,
+    "_id": "accuweather.0.Summary.TempMax_d4"
+  },
+  "accuweather.0.Summary.TempMax_d5": {
+    "type": "state",
+    "common": {
+      "name": "Max Temperature day 5",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.temperature.max.forecast.4",
+      "unit": "°C"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155041,
+    "_id": "accuweather.0.Summary.TempMax_d5"
+  },
+  "accuweather.0.Summary.TempMin_d1": {
+    "type": "state",
+    "common": {
+      "name": "Min Temperature day 1",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.temperature.min.forecast.0",
+      "unit": "°C"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155036,
+    "_id": "accuweather.0.Summary.TempMin_d1"
+  },
+  "accuweather.0.Summary.TempMin_d2": {
+    "type": "state",
+    "common": {
+      "name": "Min Temperature day 2",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.temperature.min.forecast.1",
+      "unit": "°C"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155037,
+    "_id": "accuweather.0.Summary.TempMin_d2"
+  },
+  "accuweather.0.Summary.TempMin_d3": {
+    "type": "state",
+    "common": {
+      "name": "Min Temperature day 3",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.temperature.min.forecast.2",
+      "unit": "°C"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155039,
+    "_id": "accuweather.0.Summary.TempMin_d3"
+  },
+  "accuweather.0.Summary.TempMin_d4": {
+    "type": "state",
+    "common": {
+      "name": "Min Temperature day 4",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.temperature.min.forecast.3",
+      "unit": "°C"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155040,
+    "_id": "accuweather.0.Summary.TempMin_d4"
+  },
+  "accuweather.0.Summary.TempMin_d5": {
+    "type": "state",
+    "common": {
+      "name": "Min Temperature day 5",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.temperature.min.forecast.4",
+      "unit": "°C"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155041,
+    "_id": "accuweather.0.Summary.TempMin_d5"
+  },
+  "accuweather.0.Summary.Temperature": {
+    "type": "state",
+    "common": {
+      "name": "Temperature",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.temperature.forecast.0",
+      "unit": "°C"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155034,
+    "_id": "accuweather.0.Summary.Temperature"
+  },
+  "accuweather.0.Summary.TotalLiquidVolume_d1": {
+    "type": "state",
+    "common": {
+      "name": "Total Precipitation Amount day 1",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.precipitation.forecast.0",
+      "unit": "mm"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155037,
+    "_id": "accuweather.0.Summary.TotalLiquidVolume_d1"
+  },
+  "accuweather.0.Summary.TotalLiquidVolume_d2": {
+    "type": "state",
+    "common": {
+      "name": "Total Precipitation Amount day 2",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.precipitation.forecast.1",
+      "unit": "mm"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155038,
+    "_id": "accuweather.0.Summary.TotalLiquidVolume_d2"
+  },
+  "accuweather.0.Summary.TotalLiquidVolume_d3": {
+    "type": "state",
+    "common": {
+      "name": "Total Precipitation Amount day 3",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.precipitation.forecast.2",
+      "unit": "mm"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155039,
+    "_id": "accuweather.0.Summary.TotalLiquidVolume_d3"
+  },
+  "accuweather.0.Summary.TotalLiquidVolume_d4": {
+    "type": "state",
+    "common": {
+      "name": "Total Precipitation Amount day 4",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.precipitation.forecast.3",
+      "unit": "mm"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155040,
+    "_id": "accuweather.0.Summary.TotalLiquidVolume_d4"
+  },
+  "accuweather.0.Summary.TotalLiquidVolume_d5": {
+    "type": "state",
+    "common": {
+      "name": "Total Precipitation Amount day 5",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.precipitation.forecast.4",
+      "unit": "mm"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155042,
+    "_id": "accuweather.0.Summary.TotalLiquidVolume_d5"
+  },
+  "accuweather.0.Summary.WeatherIcon": {
+    "type": "state",
+    "common": {
+      "name": "Weather Icon",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.icon.name.forecast.0"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155034,
+    "_id": "accuweather.0.Summary.WeatherIcon"
+  },
+  "accuweather.0.Summary.WeatherIconURL": {
+    "type": "state",
+    "common": {
+      "name": "SVG Weather Icon URL",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.icon.forecast.0"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155034,
+    "_id": "accuweather.0.Summary.WeatherIconURL"
+  },
+  "accuweather.0.Summary.WeatherIconURL_d1": {
+    "type": "state",
+    "common": {
+      "name": "SVG Weather Icon URL day 1",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.icon.forecast.0"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155036,
+    "_id": "accuweather.0.Summary.WeatherIconURL_d1"
+  },
+  "accuweather.0.Summary.WeatherIconURL_d2": {
+    "type": "state",
+    "common": {
+      "name": "SVG Weather Icon URL day 2",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.icon.forecast.1"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155037,
+    "_id": "accuweather.0.Summary.WeatherIconURL_d2"
+  },
+  "accuweather.0.Summary.WeatherIconURL_d3": {
+    "type": "state",
+    "common": {
+      "name": "SVG Weather Icon URL day 3",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.icon.forecast.2"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155038,
+    "_id": "accuweather.0.Summary.WeatherIconURL_d3"
+  },
+  "accuweather.0.Summary.WeatherIconURL_d4": {
+    "type": "state",
+    "common": {
+      "name": "SVG Weather Icon URL day 4",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.icon.forecast.3"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155039,
+    "_id": "accuweather.0.Summary.WeatherIconURL_d4"
+  },
+  "accuweather.0.Summary.WeatherIconURL_d5": {
+    "type": "state",
+    "common": {
+      "name": "SVG Weather Icon URL day 5",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.icon.forecast.4"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155041,
+    "_id": "accuweather.0.Summary.WeatherIconURL_d5"
+  },
+  "accuweather.0.Summary.WeatherIcon_d1": {
+    "type": "state",
+    "common": {
+      "name": "Weather Icon day 1",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.icon.name.forecast.0"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155036,
+    "_id": "accuweather.0.Summary.WeatherIcon_d1"
+  },
+  "accuweather.0.Summary.WeatherIcon_d2": {
+    "type": "state",
+    "common": {
+      "name": "Weather Icon day 2",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.icon.name.forecast.1"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155037,
+    "_id": "accuweather.0.Summary.WeatherIcon_d2"
+  },
+  "accuweather.0.Summary.WeatherIcon_d3": {
+    "type": "state",
+    "common": {
+      "name": "Weather Icon day 3",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.icon.name.forecast.2"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155038,
+    "_id": "accuweather.0.Summary.WeatherIcon_d3"
+  },
+  "accuweather.0.Summary.WeatherIcon_d4": {
+    "type": "state",
+    "common": {
+      "name": "Weather Icon day 4",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.icon.name.forecast.3"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155039,
+    "_id": "accuweather.0.Summary.WeatherIcon_d4"
+  },
+  "accuweather.0.Summary.WeatherIcon_d5": {
+    "type": "state",
+    "common": {
+      "name": "Weather Icon day 5",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.icon.name.forecast.4"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155041,
+    "_id": "accuweather.0.Summary.WeatherIcon_d5"
+  },
+  "accuweather.0.Summary.WeatherText": {
+    "type": "state",
+    "common": {
+      "name": "Weather Description",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.state.forecast.0"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155034,
+    "_id": "accuweather.0.Summary.WeatherText"
+  },
+  "accuweather.0.Summary.WeatherText_d1": {
+    "type": "state",
+    "common": {
+      "name": "Weather Description day 1",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.state.forecast.0"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155036,
+    "_id": "accuweather.0.Summary.WeatherText_d1"
+  },
+  "accuweather.0.Summary.WeatherText_d2": {
+    "type": "state",
+    "common": {
+      "name": "Weather Description day 2",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.state.forecast.1"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155037,
+    "_id": "accuweather.0.Summary.WeatherText_d2"
+  },
+  "accuweather.0.Summary.WeatherText_d3": {
+    "type": "state",
+    "common": {
+      "name": "Weather Description day 3",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.state.forecast.2"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155038,
+    "_id": "accuweather.0.Summary.WeatherText_d3"
+  },
+  "accuweather.0.Summary.WeatherText_d4": {
+    "type": "state",
+    "common": {
+      "name": "Weather Description day 4",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.state.forecast.3"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155040,
+    "_id": "accuweather.0.Summary.WeatherText_d4"
+  },
+  "accuweather.0.Summary.WeatherText_d5": {
+    "type": "state",
+    "common": {
+      "name": "Weather Description day 5",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.state.forecast.4"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155041,
+    "_id": "accuweather.0.Summary.WeatherText_d5"
+  },
+  "accuweather.0.Summary.WindDirection": {
+    "type": "state",
+    "common": {
+      "name": "Wind Direction",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.direction.wind.forecast.0",
+      "unit": "°"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155035,
+    "_id": "accuweather.0.Summary.WindDirection"
+  },
+  "accuweather.0.Summary.WindDirectionStr": {
+    "type": "state",
+    "common": {
+      "name": "Wind Direction",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.direction.wind.forecast.0",
+      "unit": ""
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155035,
+    "_id": "accuweather.0.Summary.WindDirectionStr"
+  },
+  "accuweather.0.Summary.WindDirectionStr_d1": {
+    "type": "state",
+    "common": {
+      "name": "Wind Direction day 1",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.direction.wind.forecast.0",
+      "unit": ""
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155037,
+    "_id": "accuweather.0.Summary.WindDirectionStr_d1"
+  },
+  "accuweather.0.Summary.WindDirectionStr_d2": {
+    "type": "state",
+    "common": {
+      "name": "Wind Direction day 2",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.direction.wind.forecast.1",
+      "unit": ""
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155038,
+    "_id": "accuweather.0.Summary.WindDirectionStr_d2"
+  },
+  "accuweather.0.Summary.WindDirectionStr_d3": {
+    "type": "state",
+    "common": {
+      "name": "Wind Direction day 3",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.direction.wind.forecast.2",
+      "unit": ""
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155039,
+    "_id": "accuweather.0.Summary.WindDirectionStr_d3"
+  },
+  "accuweather.0.Summary.WindDirectionStr_d4": {
+    "type": "state",
+    "common": {
+      "name": "Wind Direction day 4",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.direction.wind.forecast.3",
+      "unit": ""
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155040,
+    "_id": "accuweather.0.Summary.WindDirectionStr_d4"
+  },
+  "accuweather.0.Summary.WindDirectionStr_d5": {
+    "type": "state",
+    "common": {
+      "name": "Wind Direction day 5",
+      "type": "string",
+      "read": true,
+      "write": false,
+      "role": "weather.direction.wind.forecast.4",
+      "unit": ""
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155041,
+    "_id": "accuweather.0.Summary.WindDirectionStr_d5"
+  },
+  "accuweather.0.Summary.WindDirection_d1": {
+    "type": "state",
+    "common": {
+      "name": "Wind Direction day 1",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.direction.wind.forecast.0",
+      "unit": "°"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155036,
+    "_id": "accuweather.0.Summary.WindDirection_d1"
+  },
+  "accuweather.0.Summary.WindDirection_d2": {
+    "type": "state",
+    "common": {
+      "name": "Wind Direction day 2",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.direction.wind.forecast.1",
+      "unit": "°"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155038,
+    "_id": "accuweather.0.Summary.WindDirection_d2"
+  },
+  "accuweather.0.Summary.WindDirection_d3": {
+    "type": "state",
+    "common": {
+      "name": "Wind Direction day 3",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.direction.wind.forecast.2",
+      "unit": "°"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155039,
+    "_id": "accuweather.0.Summary.WindDirection_d3"
+  },
+  "accuweather.0.Summary.WindDirection_d4": {
+    "type": "state",
+    "common": {
+      "name": "Wind Direction day 4",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.direction.wind.forecast.3",
+      "unit": "°"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155040,
+    "_id": "accuweather.0.Summary.WindDirection_d4"
+  },
+  "accuweather.0.Summary.WindDirection_d5": {
+    "type": "state",
+    "common": {
+      "name": "Wind Direction day 5",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.direction.wind.forecast.4",
+      "unit": "°"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155041,
+    "_id": "accuweather.0.Summary.WindDirection_d5"
+  },
+  "accuweather.0.Summary.WindSpeed": {
+    "type": "state",
+    "common": {
+      "name": "Wind Speed",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.speed.wind.forecast.0",
+      "unit": "km/h"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155035,
+    "_id": "accuweather.0.Summary.WindSpeed"
+  },
+  "accuweather.0.Summary.WindSpeed_d1": {
+    "type": "state",
+    "common": {
+      "name": "Wind Speed day 1",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.speed.wind.forecast.0",
+      "unit": "km/h"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155036,
+    "_id": "accuweather.0.Summary.WindSpeed_d1"
+  },
+  "accuweather.0.Summary.WindSpeed_d2": {
+    "type": "state",
+    "common": {
+      "name": "Wind Speed day 2",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.speed.wind.forecast.1",
+      "unit": "km/h"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155038,
+    "_id": "accuweather.0.Summary.WindSpeed_d2"
+  },
+  "accuweather.0.Summary.WindSpeed_d3": {
+    "type": "state",
+    "common": {
+      "name": "Wind Speed day 3",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.speed.wind.forecast.2",
+      "unit": "km/h"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155039,
+    "_id": "accuweather.0.Summary.WindSpeed_d3"
+  },
+  "accuweather.0.Summary.WindSpeed_d4": {
+    "type": "state",
+    "common": {
+      "name": "Wind Speed day 4",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.speed.wind.forecast.3",
+      "unit": "km/h"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155040,
+    "_id": "accuweather.0.Summary.WindSpeed_d4"
+  },
+  "accuweather.0.Summary.WindSpeed_d5": {
+    "type": "state",
+    "common": {
+      "name": "Wind Speed day 5",
+      "type": "number",
+      "read": true,
+      "write": false,
+      "role": "value.speed.wind.forecast.4",
+      "unit": "km/h"
+    },
+    "native": {},
+    "from": "system.adapter.accuweather.0",
+    "user": "system.user.admin",
+    "ts": 1625222155041,
+    "_id": "accuweather.0.Summary.WindSpeed_d5"
+  }
+}

--- a/test/weather_daswetter.json
+++ b/test/weather_daswetter.json
@@ -1,0 +1,2124 @@
+{
+  "daswetter.0.NextDays.Location_1": {
+    "type": "device",
+    "common": {
+      "name": "Location Name",
+      "role": "weather"
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424672,
+    "_id": "daswetter.0.NextDays.Location_1",
+    "acl": {
+      "object": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_1": {
+    "type": "channel",
+    "common": {
+      "name": "Day 1",
+      "role": "weather"
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424673,
+    "_id": "daswetter.0.NextDays.Location_1.Day_1",
+    "acl": {
+      "object": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_1.Maximale_Temperatur_value": {
+    "type": "state",
+    "common": {
+      "name": "Maximal day temperature",
+      "type": "number",
+      "role": "value.temperature.max.forecast.0",
+      "unit": "°C",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424677,
+    "_id": "daswetter.0.NextDays.Location_1.Day_1.Maximale_Temperatur_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_1.Minimale_Temperatur_value": {
+    "type": "state",
+    "common": {
+      "name": "Minimal day temperature",
+      "type": "number",
+      "role": "value.temperature.min.forecast.0",
+      "unit": "°C",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424675,
+    "_id": "daswetter.0.NextDays.Location_1.Day_1.Minimale_Temperatur_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_1.Tag_value": {
+    "type": "state",
+    "common": {
+      "name": "Day name",
+      "type": "string",
+      "role": "dayofweek.forecast.0",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424695,
+    "_id": "daswetter.0.NextDays.Location_1.Day_1.Tag_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_1.Wetter_Symbol_id": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon name",
+      "type": "number",
+      "role": "weather.icon.name.forecast.0",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424692,
+    "_id": "daswetter.0.NextDays.Location_1.Day_1.Wetter_Symbol_id",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_1.Wetter_Symbol_id2": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon name",
+      "type": "number",
+      "role": "weather.icon.name.forecast.0",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424691,
+    "_id": "daswetter.0.NextDays.Location_1.Day_1.Wetter_Symbol_id2",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_1.Wetter_Symbol_value": {
+    "type": "state",
+    "common": {
+      "name": "Weather state URL",
+      "type": "string",
+      "role": "weather.title.forecast.0",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424689,
+    "_id": "daswetter.0.NextDays.Location_1.Day_1.Wetter_Symbol_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_1.Wetter_Symbol_value2": {
+    "type": "state",
+    "common": {
+      "name": "Weather state URL",
+      "type": "string",
+      "role": "weather.title.forecast.0",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424688,
+    "_id": "daswetter.0.NextDays.Location_1.Day_1.Wetter_Symbol_value2",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_1.Wetterbedingungen_value": {
+    "type": "state",
+    "common": {
+      "name": "Weather description",
+      "type": "string",
+      "role": "weather.state.forecast.0",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424697,
+    "_id": "daswetter.0.NextDays.Location_1.Day_1.Wetterbedingungen_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_1.Wind_id": {
+    "type": "state",
+    "common": {
+      "name": "Wind id",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.0",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424684,
+    "_id": "daswetter.0.NextDays.Location_1.Day_1.Wind_id",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_1.Wind_idB": {
+    "type": "state",
+    "common": {
+      "name": "Wind id",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.0",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424682,
+    "_id": "daswetter.0.NextDays.Location_1.Day_1.Wind_idB",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_1.Wind_value": {
+    "type": "state",
+    "common": {
+      "name": "Wind description",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.0",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424680,
+    "_id": "daswetter.0.NextDays.Location_1.Day_1.Wind_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_1.Wind_valueB": {
+    "type": "state",
+    "common": {
+      "name": "Wind description",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.0",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424679,
+    "_id": "daswetter.0.NextDays.Location_1.Day_1.Wind_valueB",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_1.iconURL": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon URL",
+      "type": "string",
+      "role": "weather.icon.forecast.0",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424694,
+    "_id": "daswetter.0.NextDays.Location_1.Day_1.iconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_1.windIconURL": {
+    "type": "state",
+    "common": {
+      "name": "Wind icon URL",
+      "type": "string",
+      "role": "weather.icon.wind.forecast.0",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424686,
+    "_id": "daswetter.0.NextDays.Location_1.Day_1.windIconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_2": {
+    "type": "channel",
+    "common": {
+      "name": "Day 2",
+      "role": "weather"
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424698,
+    "_id": "daswetter.0.NextDays.Location_1.Day_2",
+    "acl": {
+      "object": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_2.Maximale_Temperatur_value": {
+    "type": "state",
+    "common": {
+      "name": "Maximal day temperature",
+      "type": "number",
+      "role": "value.temperature.max.forecast.1",
+      "unit": "°C",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424700,
+    "_id": "daswetter.0.NextDays.Location_1.Day_2.Maximale_Temperatur_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_2.Minimale_Temperatur_value": {
+    "type": "state",
+    "common": {
+      "name": "Minimal day temperature",
+      "type": "number",
+      "role": "value.temperature.min.forecast.1",
+      "unit": "°C",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424698,
+    "_id": "daswetter.0.NextDays.Location_1.Day_2.Minimale_Temperatur_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_2.Tag_value": {
+    "type": "state",
+    "common": {
+      "name": "Day name",
+      "type": "string",
+      "role": "dayofweek.forecast.1",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424718,
+    "_id": "daswetter.0.NextDays.Location_1.Day_2.Tag_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_2.Wetter_Symbol_id": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon name",
+      "type": "number",
+      "role": "weather.icon.name.forecast.1",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424715,
+    "_id": "daswetter.0.NextDays.Location_1.Day_2.Wetter_Symbol_id",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_2.Wetter_Symbol_id2": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon name",
+      "type": "number",
+      "role": "weather.icon.name.forecast.1",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424713,
+    "_id": "daswetter.0.NextDays.Location_1.Day_2.Wetter_Symbol_id2",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_2.Wetter_Symbol_value": {
+    "type": "state",
+    "common": {
+      "name": "Weather state URL",
+      "type": "string",
+      "role": "weather.title.forecast.1",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424712,
+    "_id": "daswetter.0.NextDays.Location_1.Day_2.Wetter_Symbol_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_2.Wetter_Symbol_value2": {
+    "type": "state",
+    "common": {
+      "name": "Weather state URL",
+      "type": "string",
+      "role": "weather.title.forecast.1",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424710,
+    "_id": "daswetter.0.NextDays.Location_1.Day_2.Wetter_Symbol_value2",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_2.Wetterbedingungen_value": {
+    "type": "state",
+    "common": {
+      "name": "Weather description",
+      "type": "string",
+      "role": "weather.state.forecast.1",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424720,
+    "_id": "daswetter.0.NextDays.Location_1.Day_2.Wetterbedingungen_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_2.Wind_id": {
+    "type": "state",
+    "common": {
+      "name": "Wind id",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.1",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424707,
+    "_id": "daswetter.0.NextDays.Location_1.Day_2.Wind_id",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_2.Wind_idB": {
+    "type": "state",
+    "common": {
+      "name": "Wind id",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.1",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424705,
+    "_id": "daswetter.0.NextDays.Location_1.Day_2.Wind_idB",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_2.Wind_value": {
+    "type": "state",
+    "common": {
+      "name": "Wind description",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.1",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424704,
+    "_id": "daswetter.0.NextDays.Location_1.Day_2.Wind_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_2.Wind_valueB": {
+    "type": "state",
+    "common": {
+      "name": "Wind description",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.1",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424702,
+    "_id": "daswetter.0.NextDays.Location_1.Day_2.Wind_valueB",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_2.iconURL": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon URL",
+      "type": "string",
+      "role": "weather.icon.forecast.1",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424717,
+    "_id": "daswetter.0.NextDays.Location_1.Day_2.iconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_2.windIconURL": {
+    "type": "state",
+    "common": {
+      "name": "Wind icon URL",
+      "type": "string",
+      "role": "weather.icon.wind.forecast.1",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424709,
+    "_id": "daswetter.0.NextDays.Location_1.Day_2.windIconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_3": {
+    "type": "channel",
+    "common": {
+      "name": "Day 3",
+      "role": "weather"
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424721,
+    "_id": "daswetter.0.NextDays.Location_1.Day_3",
+    "acl": {
+      "object": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_3.Maximale_Temperatur_value": {
+    "type": "state",
+    "common": {
+      "name": "Maximal day temperature",
+      "type": "number",
+      "role": "value.temperature.max.forecast.2",
+      "unit": "°C",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424725,
+    "_id": "daswetter.0.NextDays.Location_1.Day_3.Maximale_Temperatur_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_3.Minimale_Temperatur_value": {
+    "type": "state",
+    "common": {
+      "name": "Minimal day temperature",
+      "type": "number",
+      "role": "value.temperature.min.forecast.2",
+      "unit": "°C",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424722,
+    "_id": "daswetter.0.NextDays.Location_1.Day_3.Minimale_Temperatur_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_3.Tag_value": {
+    "type": "state",
+    "common": {
+      "name": "Day name",
+      "type": "string",
+      "role": "dayofweek.forecast.2",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424745,
+    "_id": "daswetter.0.NextDays.Location_1.Day_3.Tag_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_3.Wetter_Symbol_id": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon name",
+      "type": "number",
+      "role": "weather.icon.name.forecast.2",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424742,
+    "_id": "daswetter.0.NextDays.Location_1.Day_3.Wetter_Symbol_id",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_3.Wetter_Symbol_id2": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon name",
+      "type": "number",
+      "role": "weather.icon.name.forecast.2",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424741,
+    "_id": "daswetter.0.NextDays.Location_1.Day_3.Wetter_Symbol_id2",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_3.Wetter_Symbol_value": {
+    "type": "state",
+    "common": {
+      "name": "Weather state URL",
+      "type": "string",
+      "role": "weather.title.forecast.2",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424739,
+    "_id": "daswetter.0.NextDays.Location_1.Day_3.Wetter_Symbol_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_3.Wetter_Symbol_value2": {
+    "type": "state",
+    "common": {
+      "name": "Weather state URL",
+      "type": "string",
+      "role": "weather.title.forecast.2",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424737,
+    "_id": "daswetter.0.NextDays.Location_1.Day_3.Wetter_Symbol_value2",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_3.Wetterbedingungen_value": {
+    "type": "state",
+    "common": {
+      "name": "Weather description",
+      "type": "string",
+      "role": "weather.state.forecast.2",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424746,
+    "_id": "daswetter.0.NextDays.Location_1.Day_3.Wetterbedingungen_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_3.Wind_id": {
+    "type": "state",
+    "common": {
+      "name": "Wind id",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.2",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424732,
+    "_id": "daswetter.0.NextDays.Location_1.Day_3.Wind_id",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_3.Wind_idB": {
+    "type": "state",
+    "common": {
+      "name": "Wind id",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.2",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424730,
+    "_id": "daswetter.0.NextDays.Location_1.Day_3.Wind_idB",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_3.Wind_value": {
+    "type": "state",
+    "common": {
+      "name": "Wind description",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.2",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424728,
+    "_id": "daswetter.0.NextDays.Location_1.Day_3.Wind_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_3.Wind_valueB": {
+    "type": "state",
+    "common": {
+      "name": "Wind description",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.2",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424726,
+    "_id": "daswetter.0.NextDays.Location_1.Day_3.Wind_valueB",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_3.iconURL": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon URL",
+      "type": "string",
+      "role": "weather.icon.forecast.2",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424743,
+    "_id": "daswetter.0.NextDays.Location_1.Day_3.iconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_3.windIconURL": {
+    "type": "state",
+    "common": {
+      "name": "Wind icon URL",
+      "type": "string",
+      "role": "weather.icon.wind.forecast.2",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424735,
+    "_id": "daswetter.0.NextDays.Location_1.Day_3.windIconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_4": {
+    "type": "channel",
+    "common": {
+      "name": "Day 4",
+      "role": "weather"
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424747,
+    "_id": "daswetter.0.NextDays.Location_1.Day_4",
+    "acl": {
+      "object": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_4.Maximale_Temperatur_value": {
+    "type": "state",
+    "common": {
+      "name": "Maximal day temperature",
+      "type": "number",
+      "role": "value.temperature.max.forecast.3",
+      "unit": "°C",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424750,
+    "_id": "daswetter.0.NextDays.Location_1.Day_4.Maximale_Temperatur_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_4.Minimale_Temperatur_value": {
+    "type": "state",
+    "common": {
+      "name": "Minimal day temperature",
+      "type": "number",
+      "role": "value.temperature.min.forecast.3",
+      "unit": "°C",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424748,
+    "_id": "daswetter.0.NextDays.Location_1.Day_4.Minimale_Temperatur_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_4.Tag_value": {
+    "type": "state",
+    "common": {
+      "name": "Day name",
+      "type": "string",
+      "role": "dayofweek.forecast.3",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424768,
+    "_id": "daswetter.0.NextDays.Location_1.Day_4.Tag_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_4.Wetter_Symbol_id": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon name",
+      "type": "number",
+      "role": "weather.icon.name.forecast.3",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424765,
+    "_id": "daswetter.0.NextDays.Location_1.Day_4.Wetter_Symbol_id",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_4.Wetter_Symbol_id2": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon name",
+      "type": "number",
+      "role": "weather.icon.name.forecast.3",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424764,
+    "_id": "daswetter.0.NextDays.Location_1.Day_4.Wetter_Symbol_id2",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_4.Wetter_Symbol_value": {
+    "type": "state",
+    "common": {
+      "name": "Weather state URL",
+      "type": "string",
+      "role": "weather.title.forecast.3",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424762,
+    "_id": "daswetter.0.NextDays.Location_1.Day_4.Wetter_Symbol_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_4.Wetter_Symbol_value2": {
+    "type": "state",
+    "common": {
+      "name": "Weather state URL",
+      "type": "string",
+      "role": "weather.title.forecast.3",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424761,
+    "_id": "daswetter.0.NextDays.Location_1.Day_4.Wetter_Symbol_value2",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_4.Wetterbedingungen_value": {
+    "type": "state",
+    "common": {
+      "name": "Weather description",
+      "type": "string",
+      "role": "weather.state.forecast.3",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424772,
+    "_id": "daswetter.0.NextDays.Location_1.Day_4.Wetterbedingungen_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_4.Wind_id": {
+    "type": "state",
+    "common": {
+      "name": "Wind id",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.3",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424759,
+    "_id": "daswetter.0.NextDays.Location_1.Day_4.Wind_id",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_4.Wind_idB": {
+    "type": "state",
+    "common": {
+      "name": "Wind id",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.3",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424757,
+    "_id": "daswetter.0.NextDays.Location_1.Day_4.Wind_idB",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_4.Wind_value": {
+    "type": "state",
+    "common": {
+      "name": "Wind description",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.3",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424753,
+    "_id": "daswetter.0.NextDays.Location_1.Day_4.Wind_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_4.Wind_valueB": {
+    "type": "state",
+    "common": {
+      "name": "Wind description",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.3",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424751,
+    "_id": "daswetter.0.NextDays.Location_1.Day_4.Wind_valueB",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_4.iconURL": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon URL",
+      "type": "string",
+      "role": "weather.icon.forecast.3",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424766,
+    "_id": "daswetter.0.NextDays.Location_1.Day_4.iconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_4.windIconURL": {
+    "type": "state",
+    "common": {
+      "name": "Wind icon URL",
+      "type": "string",
+      "role": "weather.icon.wind.forecast.3",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424760,
+    "_id": "daswetter.0.NextDays.Location_1.Day_4.windIconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_5": {
+    "type": "channel",
+    "common": {
+      "name": "Day 5",
+      "role": "weather"
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424773,
+    "_id": "daswetter.0.NextDays.Location_1.Day_5",
+    "acl": {
+      "object": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_5.Maximale_Temperatur_value": {
+    "type": "state",
+    "common": {
+      "name": "Maximal day temperature",
+      "type": "number",
+      "role": "value.temperature.max.forecast.4",
+      "unit": "°C",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424777,
+    "_id": "daswetter.0.NextDays.Location_1.Day_5.Maximale_Temperatur_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_5.Minimale_Temperatur_value": {
+    "type": "state",
+    "common": {
+      "name": "Minimal day temperature",
+      "type": "number",
+      "role": "value.temperature.min.forecast.4",
+      "unit": "°C",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424774,
+    "_id": "daswetter.0.NextDays.Location_1.Day_5.Minimale_Temperatur_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_5.Tag_value": {
+    "type": "state",
+    "common": {
+      "name": "Day name",
+      "type": "string",
+      "role": "dayofweek.forecast.4",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424795,
+    "_id": "daswetter.0.NextDays.Location_1.Day_5.Tag_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_5.Wetter_Symbol_id": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon name",
+      "type": "number",
+      "role": "weather.icon.name.forecast.4",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424791,
+    "_id": "daswetter.0.NextDays.Location_1.Day_5.Wetter_Symbol_id",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_5.Wetter_Symbol_id2": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon name",
+      "type": "number",
+      "role": "weather.icon.name.forecast.4",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424789,
+    "_id": "daswetter.0.NextDays.Location_1.Day_5.Wetter_Symbol_id2",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_5.Wetter_Symbol_value": {
+    "type": "state",
+    "common": {
+      "name": "Weather state URL",
+      "type": "string",
+      "role": "weather.title.forecast.4",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424787,
+    "_id": "daswetter.0.NextDays.Location_1.Day_5.Wetter_Symbol_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_5.Wetter_Symbol_value2": {
+    "type": "state",
+    "common": {
+      "name": "Weather state URL",
+      "type": "string",
+      "role": "weather.title.forecast.4",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424785,
+    "_id": "daswetter.0.NextDays.Location_1.Day_5.Wetter_Symbol_value2",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_5.Wetterbedingungen_value": {
+    "type": "state",
+    "common": {
+      "name": "Weather description",
+      "type": "string",
+      "role": "weather.state.forecast.4",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424797,
+    "_id": "daswetter.0.NextDays.Location_1.Day_5.Wetterbedingungen_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_5.Wind_id": {
+    "type": "state",
+    "common": {
+      "name": "Wind id",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.4",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424782,
+    "_id": "daswetter.0.NextDays.Location_1.Day_5.Wind_id",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_5.Wind_idB": {
+    "type": "state",
+    "common": {
+      "name": "Wind id",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.4",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424781,
+    "_id": "daswetter.0.NextDays.Location_1.Day_5.Wind_idB",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_5.Wind_value": {
+    "type": "state",
+    "common": {
+      "name": "Wind description",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.4",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424779,
+    "_id": "daswetter.0.NextDays.Location_1.Day_5.Wind_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_5.Wind_valueB": {
+    "type": "state",
+    "common": {
+      "name": "Wind description",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.4",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424778,
+    "_id": "daswetter.0.NextDays.Location_1.Day_5.Wind_valueB",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_5.iconURL": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon URL",
+      "type": "string",
+      "role": "weather.icon.forecast.4",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424794,
+    "_id": "daswetter.0.NextDays.Location_1.Day_5.iconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_5.windIconURL": {
+    "type": "state",
+    "common": {
+      "name": "Wind icon URL",
+      "type": "string",
+      "role": "weather.icon.wind.forecast.4",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424784,
+    "_id": "daswetter.0.NextDays.Location_1.Day_5.windIconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_6": {
+    "type": "channel",
+    "common": {
+      "name": "Day 6",
+      "role": "weather"
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424799,
+    "_id": "daswetter.0.NextDays.Location_1.Day_6",
+    "acl": {
+      "object": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_6.Maximale_Temperatur_value": {
+    "type": "state",
+    "common": {
+      "name": "Maximal day temperature",
+      "type": "number",
+      "role": "value.temperature.max.forecast.5",
+      "unit": "°C",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424802,
+    "_id": "daswetter.0.NextDays.Location_1.Day_6.Maximale_Temperatur_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_6.Minimale_Temperatur_value": {
+    "type": "state",
+    "common": {
+      "name": "Minimal day temperature",
+      "type": "number",
+      "role": "value.temperature.min.forecast.5",
+      "unit": "°C",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424800,
+    "_id": "daswetter.0.NextDays.Location_1.Day_6.Minimale_Temperatur_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_6.Tag_value": {
+    "type": "state",
+    "common": {
+      "name": "Day name",
+      "type": "string",
+      "role": "dayofweek.forecast.5",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424820,
+    "_id": "daswetter.0.NextDays.Location_1.Day_6.Tag_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_6.Wetter_Symbol_id": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon name",
+      "type": "number",
+      "role": "weather.icon.name.forecast.5",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424815,
+    "_id": "daswetter.0.NextDays.Location_1.Day_6.Wetter_Symbol_id",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_6.Wetter_Symbol_id2": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon name",
+      "type": "number",
+      "role": "weather.icon.name.forecast.5",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424814,
+    "_id": "daswetter.0.NextDays.Location_1.Day_6.Wetter_Symbol_id2",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_6.Wetter_Symbol_value": {
+    "type": "state",
+    "common": {
+      "name": "Weather state URL",
+      "type": "string",
+      "role": "weather.title.forecast.5",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424812,
+    "_id": "daswetter.0.NextDays.Location_1.Day_6.Wetter_Symbol_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_6.Wetter_Symbol_value2": {
+    "type": "state",
+    "common": {
+      "name": "Weather state URL",
+      "type": "string",
+      "role": "weather.title.forecast.5",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424810,
+    "_id": "daswetter.0.NextDays.Location_1.Day_6.Wetter_Symbol_value2",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_6.Wetterbedingungen_value": {
+    "type": "state",
+    "common": {
+      "name": "Weather description",
+      "type": "string",
+      "role": "weather.state.forecast.5",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424822,
+    "_id": "daswetter.0.NextDays.Location_1.Day_6.Wetterbedingungen_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_6.Wind_id": {
+    "type": "state",
+    "common": {
+      "name": "Wind id",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.5",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424807,
+    "_id": "daswetter.0.NextDays.Location_1.Day_6.Wind_id",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_6.Wind_idB": {
+    "type": "state",
+    "common": {
+      "name": "Wind id",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.5",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424806,
+    "_id": "daswetter.0.NextDays.Location_1.Day_6.Wind_idB",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_6.Wind_value": {
+    "type": "state",
+    "common": {
+      "name": "Wind description",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.5",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424804,
+    "_id": "daswetter.0.NextDays.Location_1.Day_6.Wind_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_6.Wind_valueB": {
+    "type": "state",
+    "common": {
+      "name": "Wind description",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.5",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424803,
+    "_id": "daswetter.0.NextDays.Location_1.Day_6.Wind_valueB",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_6.iconURL": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon URL",
+      "type": "string",
+      "role": "weather.icon.forecast.5",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424817,
+    "_id": "daswetter.0.NextDays.Location_1.Day_6.iconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_6.windIconURL": {
+    "type": "state",
+    "common": {
+      "name": "Wind icon URL",
+      "type": "string",
+      "role": "weather.icon.wind.forecast.5",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424809,
+    "_id": "daswetter.0.NextDays.Location_1.Day_6.windIconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_7": {
+    "type": "channel",
+    "common": {
+      "name": "Day 7",
+      "role": "weather"
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424824,
+    "_id": "daswetter.0.NextDays.Location_1.Day_7",
+    "acl": {
+      "object": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_7.Maximale_Temperatur_value": {
+    "type": "state",
+    "common": {
+      "name": "Maximal day temperature",
+      "type": "number",
+      "role": "value.temperature.max.forecast.6",
+      "unit": "°C",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424826,
+    "_id": "daswetter.0.NextDays.Location_1.Day_7.Maximale_Temperatur_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_7.Minimale_Temperatur_value": {
+    "type": "state",
+    "common": {
+      "name": "Minimal day temperature",
+      "type": "number",
+      "role": "value.temperature.min.forecast.6",
+      "unit": "°C",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424824,
+    "_id": "daswetter.0.NextDays.Location_1.Day_7.Minimale_Temperatur_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_7.Tag_value": {
+    "type": "state",
+    "common": {
+      "name": "Day name",
+      "type": "string",
+      "role": "dayofweek.forecast.6",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424844,
+    "_id": "daswetter.0.NextDays.Location_1.Day_7.Tag_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_7.Wetter_Symbol_id": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon name",
+      "type": "number",
+      "role": "weather.icon.name.forecast.6",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424841,
+    "_id": "daswetter.0.NextDays.Location_1.Day_7.Wetter_Symbol_id",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_7.Wetter_Symbol_id2": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon name",
+      "type": "number",
+      "role": "weather.icon.name.forecast.6",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424840,
+    "_id": "daswetter.0.NextDays.Location_1.Day_7.Wetter_Symbol_id2",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_7.Wetter_Symbol_value": {
+    "type": "state",
+    "common": {
+      "name": "Weather state URL",
+      "type": "string",
+      "role": "weather.title.forecast.6",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424837,
+    "_id": "daswetter.0.NextDays.Location_1.Day_7.Wetter_Symbol_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_7.Wetter_Symbol_value2": {
+    "type": "state",
+    "common": {
+      "name": "Weather state URL",
+      "type": "string",
+      "role": "weather.title.forecast.6",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424835,
+    "_id": "daswetter.0.NextDays.Location_1.Day_7.Wetter_Symbol_value2",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_7.Wetterbedingungen_value": {
+    "type": "state",
+    "common": {
+      "name": "Weather description",
+      "type": "string",
+      "role": "weather.state.forecast.6",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424846,
+    "_id": "daswetter.0.NextDays.Location_1.Day_7.Wetterbedingungen_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_7.Wind_id": {
+    "type": "state",
+    "common": {
+      "name": "Wind id",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.6",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424833,
+    "_id": "daswetter.0.NextDays.Location_1.Day_7.Wind_id",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_7.Wind_idB": {
+    "type": "state",
+    "common": {
+      "name": "Wind id",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.6",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424831,
+    "_id": "daswetter.0.NextDays.Location_1.Day_7.Wind_idB",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_7.Wind_value": {
+    "type": "state",
+    "common": {
+      "name": "Wind description",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.6",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424830,
+    "_id": "daswetter.0.NextDays.Location_1.Day_7.Wind_value",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_7.Wind_valueB": {
+    "type": "state",
+    "common": {
+      "name": "Wind description",
+      "type": "string",
+      "role": "weather.direction.wind.forecast.6",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424828,
+    "_id": "daswetter.0.NextDays.Location_1.Day_7.Wind_valueB",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_7.iconURL": {
+    "type": "state",
+    "common": {
+      "name": "Weather icon URL",
+      "type": "string",
+      "role": "weather.icon.forecast.6",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424843,
+    "_id": "daswetter.0.NextDays.Location_1.Day_7.iconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Day_7.windIconURL": {
+    "type": "state",
+    "common": {
+      "name": "Wind icon URL",
+      "type": "string",
+      "role": "weather.icon.wind.forecast.6",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424834,
+    "_id": "daswetter.0.NextDays.Location_1.Day_7.windIconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "daswetter.0.NextDays.Location_1.Location": {
+    "type": "state",
+    "common": {
+      "name": "Location",
+      "type": "string",
+      "role": "location",
+      "read": true,
+      "write": false
+    },
+    "from": "system.adapter.daswetter.0",
+    "user": "system.user.admin",
+    "ts": 1625142424669,
+    "_id": "daswetter.0.NextDays.Location_1.Location",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  }
+}

--- a/test/weather_weatherunderground.json
+++ b/test/weather_weatherunderground.json
@@ -1,0 +1,2933 @@
+{
+  "weatherunderground.0.forecast": {
+    "type": "device",
+    "role": "forecast",
+    "common": {
+      "name": "Forecast for next 4 days days and current conditions"
+    },
+    "native": {
+      "location": "Bonn"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451296,
+    "_id": "weatherunderground.0.forecast",
+    "acl": {
+      "object": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d": {
+    "type": "channel",
+    "role": "forecast",
+    "common": {
+      "name": "in 0days"
+    },
+    "native": {
+      "location": "Bonn"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451333,
+    "_id": "weatherunderground.0.forecast.0d",
+    "acl": {
+      "object": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.date": {
+    "type": "state",
+    "common": {
+      "name": "forecast for",
+      "type": "string",
+      "role": "date.forecast.0",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.date"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451333,
+    "_id": "weatherunderground.0.forecast.0d.date",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.humidity": {
+    "type": "state",
+    "common": {
+      "name": "average humidity",
+      "role": "value.humidity.forecast.0",
+      "unit": "%",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.avehumidity"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451351,
+    "_id": "weatherunderground.0.forecast.0d.humidity",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.humidityMax": {
+    "type": "state",
+    "common": {
+      "name": "maximum humidity",
+      "role": "value.humidity.max.forecast.0",
+      "unit": "%",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.maxhumidity"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451352,
+    "_id": "weatherunderground.0.forecast.0d.humidityMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.humidityMin": {
+    "type": "state",
+    "common": {
+      "name": "minimum humidity",
+      "role": "value.humidity.min.forecast.0",
+      "unit": "%",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.minhumidity"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451353,
+    "_id": "weatherunderground.0.forecast.0d.humidityMin",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.icon": {
+    "type": "state",
+    "common": {
+      "name": "forecast icon",
+      "type": "number",
+      "role": "weather.icon.name.forecast.0",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.icon"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451342,
+    "_id": "weatherunderground.0.forecast.0d.icon",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.iconURL": {
+    "type": "state",
+    "common": {
+      "name": "forecast icon url",
+      "type": "string",
+      "role": "weather.icon.forecast.0",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.icon_url"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451344,
+    "_id": "weatherunderground.0.forecast.0d.iconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.precipitationAllDay": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative precipitation all day forecast",
+      "role": "value.precipitation.today.forecast.0",
+      "unit": "mm",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.qpf_allday.mm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451336,
+    "_id": "weatherunderground.0.forecast.0d.precipitationAllDay",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.precipitationChance": {
+    "type": "state",
+    "common": {
+      "name": "Percentage of precipitation",
+      "type": "number",
+      "role": "value.precipitation.forecast.0",
+      "unit": "%",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.pop"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451345,
+    "_id": "weatherunderground.0.forecast.0d.precipitationChance",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.precipitationDay": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative precipitation day forecast",
+      "role": "value.precipitation.day.forecast.0",
+      "unit": "mm",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.qpf_day.mm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451337,
+    "_id": "weatherunderground.0.forecast.0d.precipitationDay",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.precipitationNight": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative precipitation night forecast",
+      "role": "value.precipitation.night.forecast.0",
+      "unit": "mm",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.qpf_night.mm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451338,
+    "_id": "weatherunderground.0.forecast.0d.precipitationNight",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.snowAllDay": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative snow all day forecast",
+      "type": "number",
+      "role": "value.snow.forecast.0",
+      "unit": "cm",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.snow_allday.cm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451338,
+    "_id": "weatherunderground.0.forecast.0d.snowAllDay",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.snowDay": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative snow day forecast",
+      "role": "value.snow.day.forecast.0",
+      "type": "number",
+      "unit": "cm",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.snow_day.cm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451339,
+    "_id": "weatherunderground.0.forecast.0d.snowDay",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.snowNight": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative snow night forecast",
+      "role": "value.snow.night.forecast.0",
+      "type": "number",
+      "unit": "cm",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.snow_night.cm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451340,
+    "_id": "weatherunderground.0.forecast.0d.snowNight",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.state": {
+    "type": "state",
+    "common": {
+      "name": "forecast state",
+      "type": "string",
+      "role": "weather.state.forecast.0",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.state"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451344,
+    "_id": "weatherunderground.0.forecast.0d.state",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.tempMax": {
+    "type": "state",
+    "common": {
+      "name": "high temperature",
+      "type": "number",
+      "unit": "°C",
+      "role": "value.temperature.max.forecast.0",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.high.celsius"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451334,
+    "_id": "weatherunderground.0.forecast.0d.tempMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.tempMin": {
+    "type": "state",
+    "common": {
+      "name": "low temperature",
+      "type": "number",
+      "unit": "°C",
+      "role": "value.temperature.min.forecast.0",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.low.celsius"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451335,
+    "_id": "weatherunderground.0.forecast.0d.tempMin",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.windDegrees": {
+    "type": "state",
+    "common": {
+      "name": "average wind direction degrees",
+      "role": "value.direction.wind.forecast.0",
+      "unit": "°",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.avewind.degrees"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451350,
+    "_id": "weatherunderground.0.forecast.0d.windDegrees",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.windDegreesMax": {
+    "type": "state",
+    "common": {
+      "name": "max. wind direction",
+      "role": "value.direction.max.wind.forecast.0",
+      "unit": "°",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.maxwind.degrees"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451348,
+    "_id": "weatherunderground.0.forecast.0d.windDegreesMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.windDirection": {
+    "type": "state",
+    "common": {
+      "name": "average wind direction",
+      "role": "weather.direction.wind.forecast.0",
+      "type": "string",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.avewind.dir"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451349,
+    "_id": "weatherunderground.0.forecast.0d.windDirection",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.windDirectionMax": {
+    "type": "state",
+    "common": {
+      "name": "max. wind direction",
+      "role": "weather.direction.max.wind.forecast.0",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.maxwind.dir"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451346,
+    "_id": "weatherunderground.0.forecast.0d.windDirectionMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.windSpeed": {
+    "type": "state",
+    "common": {
+      "name": "average wind speed",
+      "role": "value.speed.wind.forecast.0",
+      "unit": "km/h",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.avewind.kph"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451341,
+    "_id": "weatherunderground.0.forecast.0d.windSpeed",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.0d.windSpeedMax": {
+    "type": "state",
+    "common": {
+      "name": "max. wind speed",
+      "role": "value.speed.max.wind.forecast.0",
+      "unit": "km/h",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.0d.maxwind.kph"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451341,
+    "_id": "weatherunderground.0.forecast.0d.windSpeedMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d": {
+    "type": "channel",
+    "role": "forecast",
+    "common": {
+      "name": "in 1days"
+    },
+    "native": {
+      "location": "Bonn"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451354,
+    "_id": "weatherunderground.0.forecast.1d",
+    "acl": {
+      "object": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.date": {
+    "type": "state",
+    "common": {
+      "name": "forecast for",
+      "type": "string",
+      "role": "date.forecast.1",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.date"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451355,
+    "_id": "weatherunderground.0.forecast.1d.date",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.humidity": {
+    "type": "state",
+    "common": {
+      "name": "average humidity",
+      "role": "value.humidity.forecast.1",
+      "unit": "%",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.avehumidity"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451372,
+    "_id": "weatherunderground.0.forecast.1d.humidity",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.humidityMax": {
+    "type": "state",
+    "common": {
+      "name": "maximum humidity",
+      "role": "value.humidity.max.forecast.1",
+      "unit": "%",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.maxhumidity"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451373,
+    "_id": "weatherunderground.0.forecast.1d.humidityMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.humidityMin": {
+    "type": "state",
+    "common": {
+      "name": "minimum humidity",
+      "role": "value.humidity.min.forecast.1",
+      "unit": "%",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.minhumidity"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451373,
+    "_id": "weatherunderground.0.forecast.1d.humidityMin",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.icon": {
+    "type": "state",
+    "common": {
+      "name": "forecast icon",
+      "type": "number",
+      "role": "weather.icon.name.forecast.1",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.icon"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451364,
+    "_id": "weatherunderground.0.forecast.1d.icon",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.iconURL": {
+    "type": "state",
+    "common": {
+      "name": "forecast icon url",
+      "type": "string",
+      "role": "weather.icon.forecast.1",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.icon_url"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451366,
+    "_id": "weatherunderground.0.forecast.1d.iconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.precipitationAllDay": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative precipitation all day forecast",
+      "role": "value.precipitation.today.forecast.1",
+      "unit": "mm",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.qpf_allday.mm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451357,
+    "_id": "weatherunderground.0.forecast.1d.precipitationAllDay",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.precipitationChance": {
+    "type": "state",
+    "common": {
+      "name": "Percentage of precipitation",
+      "type": "number",
+      "role": "value.precipitation.forecast.1",
+      "unit": "%",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.pop"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451367,
+    "_id": "weatherunderground.0.forecast.1d.precipitationChance",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.precipitationDay": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative precipitation day forecast",
+      "role": "value.precipitation.day.forecast.1",
+      "unit": "mm",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.qpf_day.mm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451357,
+    "_id": "weatherunderground.0.forecast.1d.precipitationDay",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.precipitationNight": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative precipitation night forecast",
+      "role": "value.precipitation.night.forecast.1",
+      "unit": "mm",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.qpf_night.mm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451358,
+    "_id": "weatherunderground.0.forecast.1d.precipitationNight",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.snowAllDay": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative snow all day forecast",
+      "type": "number",
+      "role": "value.snow.forecast.1",
+      "unit": "cm",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.snow_allday.cm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451359,
+    "_id": "weatherunderground.0.forecast.1d.snowAllDay",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.snowDay": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative snow day forecast",
+      "role": "value.snow.day.forecast.1",
+      "type": "number",
+      "unit": "cm",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.snow_day.cm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451359,
+    "_id": "weatherunderground.0.forecast.1d.snowDay",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.snowNight": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative snow night forecast",
+      "role": "value.snow.night.forecast.1",
+      "type": "number",
+      "unit": "cm",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.snow_night.cm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451360,
+    "_id": "weatherunderground.0.forecast.1d.snowNight",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.state": {
+    "type": "state",
+    "common": {
+      "name": "forecast state",
+      "type": "string",
+      "role": "weather.state.forecast.1",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.state"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451365,
+    "_id": "weatherunderground.0.forecast.1d.state",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.tempMax": {
+    "type": "state",
+    "common": {
+      "name": "high temperature",
+      "type": "number",
+      "unit": "°C",
+      "role": "value.temperature.max.forecast.1",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.high.celsius"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451356,
+    "_id": "weatherunderground.0.forecast.1d.tempMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.tempMin": {
+    "type": "state",
+    "common": {
+      "name": "low temperature",
+      "type": "number",
+      "unit": "°C",
+      "role": "value.temperature.min.forecast.1",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.low.celsius"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451356,
+    "_id": "weatherunderground.0.forecast.1d.tempMin",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.windDegrees": {
+    "type": "state",
+    "common": {
+      "name": "average wind direction degrees",
+      "role": "value.direction.wind.forecast.1",
+      "unit": "°",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.avewind.degrees"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451371,
+    "_id": "weatherunderground.0.forecast.1d.windDegrees",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.windDegreesMax": {
+    "type": "state",
+    "common": {
+      "name": "max. wind direction",
+      "role": "value.direction.max.wind.forecast.1",
+      "unit": "°",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.maxwind.degrees"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451369,
+    "_id": "weatherunderground.0.forecast.1d.windDegreesMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.windDirection": {
+    "type": "state",
+    "common": {
+      "name": "average wind direction",
+      "role": "weather.direction.wind.forecast.1",
+      "type": "string",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.avewind.dir"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451370,
+    "_id": "weatherunderground.0.forecast.1d.windDirection",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.windDirectionMax": {
+    "type": "state",
+    "common": {
+      "name": "max. wind direction",
+      "role": "weather.direction.max.wind.forecast.1",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.maxwind.dir"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451368,
+    "_id": "weatherunderground.0.forecast.1d.windDirectionMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.windSpeed": {
+    "type": "state",
+    "common": {
+      "name": "average wind speed",
+      "role": "value.speed.wind.forecast.1",
+      "unit": "km/h",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.avewind.kph"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451362,
+    "_id": "weatherunderground.0.forecast.1d.windSpeed",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.1d.windSpeedMax": {
+    "type": "state",
+    "common": {
+      "name": "max. wind speed",
+      "role": "value.speed.max.wind.forecast.1",
+      "unit": "km/h",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.1d.maxwind.kph"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451360,
+    "_id": "weatherunderground.0.forecast.1d.windSpeedMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d": {
+    "type": "channel",
+    "role": "forecast",
+    "common": {
+      "name": "in 2days"
+    },
+    "native": {
+      "location": "Bonn"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451374,
+    "_id": "weatherunderground.0.forecast.2d",
+    "acl": {
+      "object": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.date": {
+    "type": "state",
+    "common": {
+      "name": "forecast for",
+      "type": "string",
+      "role": "date.forecast.2",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.date"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451375,
+    "_id": "weatherunderground.0.forecast.2d.date",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.humidity": {
+    "type": "state",
+    "common": {
+      "name": "average humidity",
+      "role": "value.humidity.forecast.2",
+      "unit": "%",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.avehumidity"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451396,
+    "_id": "weatherunderground.0.forecast.2d.humidity",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.humidityMax": {
+    "type": "state",
+    "common": {
+      "name": "maximum humidity",
+      "role": "value.humidity.max.forecast.2",
+      "unit": "%",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.maxhumidity"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451397,
+    "_id": "weatherunderground.0.forecast.2d.humidityMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.humidityMin": {
+    "type": "state",
+    "common": {
+      "name": "minimum humidity",
+      "role": "value.humidity.min.forecast.2",
+      "unit": "%",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.minhumidity"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451398,
+    "_id": "weatherunderground.0.forecast.2d.humidityMin",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.icon": {
+    "type": "state",
+    "common": {
+      "name": "forecast icon",
+      "type": "number",
+      "role": "weather.icon.name.forecast.2",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.icon"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451387,
+    "_id": "weatherunderground.0.forecast.2d.icon",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.iconURL": {
+    "type": "state",
+    "common": {
+      "name": "forecast icon url",
+      "type": "string",
+      "role": "weather.icon.forecast.2",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.icon_url"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451389,
+    "_id": "weatherunderground.0.forecast.2d.iconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.precipitationAllDay": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative precipitation all day forecast",
+      "role": "value.precipitation.today.forecast.2",
+      "unit": "mm",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.qpf_allday.mm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451378,
+    "_id": "weatherunderground.0.forecast.2d.precipitationAllDay",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.precipitationChance": {
+    "type": "state",
+    "common": {
+      "name": "Percentage of precipitation",
+      "type": "number",
+      "role": "value.precipitation.forecast.2",
+      "unit": "%",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.pop"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451390,
+    "_id": "weatherunderground.0.forecast.2d.precipitationChance",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.precipitationDay": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative precipitation day forecast",
+      "role": "value.precipitation.day.forecast.2",
+      "unit": "mm",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.qpf_day.mm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451379,
+    "_id": "weatherunderground.0.forecast.2d.precipitationDay",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.precipitationNight": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative precipitation night forecast",
+      "role": "value.precipitation.night.forecast.2",
+      "unit": "mm",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.qpf_night.mm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451380,
+    "_id": "weatherunderground.0.forecast.2d.precipitationNight",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.snowAllDay": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative snow all day forecast",
+      "type": "number",
+      "role": "value.snow.forecast.2",
+      "unit": "cm",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.snow_allday.cm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451381,
+    "_id": "weatherunderground.0.forecast.2d.snowAllDay",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.snowDay": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative snow day forecast",
+      "role": "value.snow.day.forecast.2",
+      "type": "number",
+      "unit": "cm",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.snow_day.cm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451382,
+    "_id": "weatherunderground.0.forecast.2d.snowDay",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.snowNight": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative snow night forecast",
+      "role": "value.snow.night.forecast.2",
+      "type": "number",
+      "unit": "cm",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.snow_night.cm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451384,
+    "_id": "weatherunderground.0.forecast.2d.snowNight",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.state": {
+    "type": "state",
+    "common": {
+      "name": "forecast state",
+      "type": "string",
+      "role": "weather.state.forecast.2",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.state"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451388,
+    "_id": "weatherunderground.0.forecast.2d.state",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.tempMax": {
+    "type": "state",
+    "common": {
+      "name": "high temperature",
+      "type": "number",
+      "unit": "°C",
+      "role": "value.temperature.max.forecast.2",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.high.celsius"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451375,
+    "_id": "weatherunderground.0.forecast.2d.tempMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.tempMin": {
+    "type": "state",
+    "common": {
+      "name": "low temperature",
+      "type": "number",
+      "unit": "°C",
+      "role": "value.temperature.min.forecast.2",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.low.celsius"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451376,
+    "_id": "weatherunderground.0.forecast.2d.tempMin",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.windDegrees": {
+    "type": "state",
+    "common": {
+      "name": "average wind direction degrees",
+      "role": "value.direction.wind.forecast.2",
+      "unit": "°",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.avewind.degrees"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451394,
+    "_id": "weatherunderground.0.forecast.2d.windDegrees",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.windDegreesMax": {
+    "type": "state",
+    "common": {
+      "name": "max. wind direction",
+      "role": "value.direction.max.wind.forecast.2",
+      "unit": "°",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.maxwind.degrees"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451392,
+    "_id": "weatherunderground.0.forecast.2d.windDegreesMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.windDirection": {
+    "type": "state",
+    "common": {
+      "name": "average wind direction",
+      "role": "weather.direction.wind.forecast.2",
+      "type": "string",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.avewind.dir"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451393,
+    "_id": "weatherunderground.0.forecast.2d.windDirection",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.windDirectionMax": {
+    "type": "state",
+    "common": {
+      "name": "max. wind direction",
+      "role": "weather.direction.max.wind.forecast.2",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.maxwind.dir"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451391,
+    "_id": "weatherunderground.0.forecast.2d.windDirectionMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.windSpeed": {
+    "type": "state",
+    "common": {
+      "name": "average wind speed",
+      "role": "value.speed.wind.forecast.2",
+      "unit": "km/h",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.avewind.kph"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451386,
+    "_id": "weatherunderground.0.forecast.2d.windSpeed",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.2d.windSpeedMax": {
+    "type": "state",
+    "common": {
+      "name": "max. wind speed",
+      "role": "value.speed.max.wind.forecast.2",
+      "unit": "km/h",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.2d.maxwind.kph"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451384,
+    "_id": "weatherunderground.0.forecast.2d.windSpeedMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d": {
+    "type": "channel",
+    "role": "forecast",
+    "common": {
+      "name": "in 3days"
+    },
+    "native": {
+      "location": "Bonn"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451399,
+    "_id": "weatherunderground.0.forecast.3d",
+    "acl": {
+      "object": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.date": {
+    "type": "state",
+    "common": {
+      "name": "forecast for",
+      "type": "string",
+      "role": "date.forecast.3",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.date"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451400,
+    "_id": "weatherunderground.0.forecast.3d.date",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.humidity": {
+    "type": "state",
+    "common": {
+      "name": "average humidity",
+      "role": "value.humidity.forecast.3",
+      "unit": "%",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.avehumidity"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451416,
+    "_id": "weatherunderground.0.forecast.3d.humidity",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.humidityMax": {
+    "type": "state",
+    "common": {
+      "name": "maximum humidity",
+      "role": "value.humidity.max.forecast.3",
+      "unit": "%",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.maxhumidity"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451417,
+    "_id": "weatherunderground.0.forecast.3d.humidityMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.humidityMin": {
+    "type": "state",
+    "common": {
+      "name": "minimum humidity",
+      "role": "value.humidity.min.forecast.3",
+      "unit": "%",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.minhumidity"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451417,
+    "_id": "weatherunderground.0.forecast.3d.humidityMin",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.icon": {
+    "type": "state",
+    "common": {
+      "name": "forecast icon",
+      "type": "number",
+      "role": "weather.icon.name.forecast.3",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.icon"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451409,
+    "_id": "weatherunderground.0.forecast.3d.icon",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.iconURL": {
+    "type": "state",
+    "common": {
+      "name": "forecast icon url",
+      "type": "string",
+      "role": "weather.icon.forecast.3",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.icon_url"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451411,
+    "_id": "weatherunderground.0.forecast.3d.iconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.precipitationAllDay": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative precipitation all day forecast",
+      "role": "value.precipitation.today.forecast.3",
+      "unit": "mm",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.qpf_allday.mm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451403,
+    "_id": "weatherunderground.0.forecast.3d.precipitationAllDay",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.precipitationChance": {
+    "type": "state",
+    "common": {
+      "name": "Percentage of precipitation",
+      "type": "number",
+      "role": "value.precipitation.forecast.3",
+      "unit": "%",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.pop"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451412,
+    "_id": "weatherunderground.0.forecast.3d.precipitationChance",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.precipitationDay": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative precipitation day forecast",
+      "role": "value.precipitation.day.forecast.3",
+      "unit": "mm",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.qpf_day.mm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451404,
+    "_id": "weatherunderground.0.forecast.3d.precipitationDay",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.precipitationNight": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative precipitation night forecast",
+      "role": "value.precipitation.night.forecast.3",
+      "unit": "mm",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.qpf_night.mm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451405,
+    "_id": "weatherunderground.0.forecast.3d.precipitationNight",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.snowAllDay": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative snow all day forecast",
+      "type": "number",
+      "role": "value.snow.forecast.3",
+      "unit": "cm",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.snow_allday.cm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451406,
+    "_id": "weatherunderground.0.forecast.3d.snowAllDay",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.snowDay": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative snow day forecast",
+      "role": "value.snow.day.forecast.3",
+      "type": "number",
+      "unit": "cm",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.snow_day.cm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451406,
+    "_id": "weatherunderground.0.forecast.3d.snowDay",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.snowNight": {
+    "type": "state",
+    "common": {
+      "name": "Quantitative snow night forecast",
+      "role": "value.snow.night.forecast.3",
+      "type": "number",
+      "unit": "cm",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.snow_night.cm"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451407,
+    "_id": "weatherunderground.0.forecast.3d.snowNight",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.state": {
+    "type": "state",
+    "common": {
+      "name": "forecast state",
+      "type": "string",
+      "role": "weather.state.forecast.3",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.state"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451410,
+    "_id": "weatherunderground.0.forecast.3d.state",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.tempMax": {
+    "type": "state",
+    "common": {
+      "name": "high temperature",
+      "type": "number",
+      "unit": "°C",
+      "role": "value.temperature.max.forecast.3",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.high.celsius"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451401,
+    "_id": "weatherunderground.0.forecast.3d.tempMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.tempMin": {
+    "type": "state",
+    "common": {
+      "name": "low temperature",
+      "type": "number",
+      "unit": "°C",
+      "role": "value.temperature.min.forecast.3",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.low.celsius"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451402,
+    "_id": "weatherunderground.0.forecast.3d.tempMin",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.windDegrees": {
+    "type": "state",
+    "common": {
+      "name": "average wind direction degrees",
+      "role": "value.direction.wind.forecast.3",
+      "unit": "°",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.avewind.degrees"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451415,
+    "_id": "weatherunderground.0.forecast.3d.windDegrees",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.windDegreesMax": {
+    "type": "state",
+    "common": {
+      "name": "max. wind direction",
+      "role": "value.direction.max.wind.forecast.3",
+      "unit": "°",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.maxwind.degrees"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451413,
+    "_id": "weatherunderground.0.forecast.3d.windDegreesMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.windDirection": {
+    "type": "state",
+    "common": {
+      "name": "average wind direction",
+      "role": "weather.direction.wind.forecast.3",
+      "type": "string",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.avewind.dir"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451414,
+    "_id": "weatherunderground.0.forecast.3d.windDirection",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.windDirectionMax": {
+    "type": "state",
+    "common": {
+      "name": "max. wind direction",
+      "role": "weather.direction.max.wind.forecast.3",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.maxwind.dir"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451412,
+    "_id": "weatherunderground.0.forecast.3d.windDirectionMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.windSpeed": {
+    "type": "state",
+    "common": {
+      "name": "average wind speed",
+      "role": "value.speed.wind.forecast.3",
+      "unit": "km/h",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.avewind.kph"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451409,
+    "_id": "weatherunderground.0.forecast.3d.windSpeed",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.3d.windSpeedMax": {
+    "type": "state",
+    "common": {
+      "name": "max. wind speed",
+      "role": "value.speed.max.wind.forecast.3",
+      "unit": "km/h",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "forecast.3d.maxwind.kph"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451408,
+    "_id": "weatherunderground.0.forecast.3d.windSpeedMax",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current": {
+    "type": "channel",
+    "common": {
+      "name": "Current conditions",
+      "role": "weather"
+    },
+    "native": {
+      "location": "Bonn"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451299,
+    "_id": "weatherunderground.0.forecast.current",
+    "acl": {
+      "object": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.UV": {
+    "type": "state",
+    "common": {
+      "name": "UV-Index",
+      "role": "value.uv",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current.UV"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451321,
+    "_id": "weatherunderground.0.forecast.current.UV",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.dewPoint": {
+    "type": "state",
+    "common": {
+      "name": "Dewpoint",
+      "role": "value.temperature.dewpoint",
+      "type": "number",
+      "unit": "°C",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.dewpoint_c"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451313,
+    "_id": "weatherunderground.0.forecast.current.dewPoint",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.displayLocationElevation": {
+    "type": "state",
+    "common": {
+      "name": "Display location elevation",
+      "role": "value.gps.elevation",
+      "type": "number",
+      "unit": "m",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.display_location.elevation"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451303,
+    "_id": "weatherunderground.0.forecast.current.displayLocationElevation",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.displayLocationFull": {
+    "type": "state",
+    "common": {
+      "name": "Display location full name",
+      "role": "location",
+      "type": "string"
+    },
+    "native": {
+      "id": "current_observation.display_location.full"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451301,
+    "_id": "weatherunderground.0.forecast.current.displayLocationFull",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.displayLocationLatitude": {
+    "type": "state",
+    "common": {
+      "name": "Display location latitude",
+      "role": "value.gps.latitude",
+      "type": "number",
+      "unit": "°",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.display_location.latitude"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451301,
+    "_id": "weatherunderground.0.forecast.current.displayLocationLatitude",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.displayLocationLongitude": {
+    "type": "state",
+    "common": {
+      "name": "Display location longitude",
+      "role": "value.gps.longitude",
+      "type": "number",
+      "unit": "°",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.display_location.longitude"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451302,
+    "_id": "weatherunderground.0.forecast.current.displayLocationLongitude",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.feelsLike": {
+    "type": "state",
+    "common": {
+      "name": "Temperature feels like",
+      "role": "value.temperature.feelslike",
+      "type": "number",
+      "unit": "°C",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.feelslike_c"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451315,
+    "_id": "weatherunderground.0.forecast.current.feelsLike",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.forecastURL": {
+    "type": "state",
+    "common": {
+      "name": "URL to wu-forecast page",
+      "role": "weather.chart.url.forecast",
+      "type": "string",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.forecast_url"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451324,
+    "_id": "weatherunderground.0.forecast.current.forecastURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.historyURL": {
+    "type": "state",
+    "common": {
+      "name": "URL to wu-history page",
+      "role": "weather.chart.url",
+      "type": "string",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.history_url"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451325,
+    "_id": "weatherunderground.0.forecast.current.historyURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.iconURL": {
+    "type": "state",
+    "common": {
+      "name": "URL to current weather icon",
+      "role": "weather.icon",
+      "type": "number",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.icon_url"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451323,
+    "_id": "weatherunderground.0.forecast.current.iconURL",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.localTimeRFC822": {
+    "type": "state",
+    "common": {
+      "name": "Local time (rfc822)",
+      "role": "state",
+      "type": "string",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.local_time_rfc822"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451309,
+    "_id": "weatherunderground.0.forecast.current.localTimeRFC822",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.observationLocationElevation": {
+    "type": "state",
+    "common": {
+      "name": "Observation location elevation",
+      "role": "value.gps.elevation",
+      "type": "number",
+      "unit": "m",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.observation_location.elevation"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451307,
+    "_id": "weatherunderground.0.forecast.current.observationLocationElevation",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.observationLocationFull": {
+    "type": "state",
+    "common": {
+      "name": "Observation location full name",
+      "role": "location",
+      "type": "string"
+    },
+    "native": {
+      "id": "current_observation.observation_location.full"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451304,
+    "_id": "weatherunderground.0.forecast.current.observationLocationFull",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.observationLocationLatitude": {
+    "type": "state",
+    "common": {
+      "name": "Observation location latitude",
+      "role": "value.gps.latitude",
+      "type": "number",
+      "unit": "°",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.observation_location.latitude"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451305,
+    "_id": "weatherunderground.0.forecast.current.observationLocationLatitude",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.observationLocationLongitude": {
+    "type": "state",
+    "common": {
+      "name": "Observation location longitude",
+      "role": "value.gps.longitude",
+      "type": "number",
+      "unit": "°",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.observation_location.longitude"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451306,
+    "_id": "weatherunderground.0.forecast.current.observationLocationLongitude",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.observationLocationStationID": {
+    "type": "state",
+    "common": {
+      "name": "WU station ID",
+      "role": "state",
+      "type": "string",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.observation_location.station_id"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451308,
+    "_id": "weatherunderground.0.forecast.current.observationLocationStationID",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.observationTime": {
+    "type": "state",
+    "common": {
+      "name": "Observation time (rfc822)",
+      "role": "date",
+      "type": "string",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.local_epoch"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451311,
+    "_id": "weatherunderground.0.forecast.current.observationTime",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.observationTimeRFC822": {
+    "type": "state",
+    "common": {
+      "name": "Observation time (rfc822)",
+      "role": "state",
+      "type": "string",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.observation_time_rfc822"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451310,
+    "_id": "weatherunderground.0.forecast.current.observationTimeRFC822",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.precipitationDay": {
+    "type": "state",
+    "common": {
+      "name": "Precipitation (today)",
+      "role": "value.precipitation.today",
+      "type": "number",
+      "unit": "mm",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.precip_today_metric"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451323,
+    "_id": "weatherunderground.0.forecast.current.precipitationDay",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.precipitationHour": {
+    "type": "state",
+    "common": {
+      "name": "Precipitation (last 1h)",
+      "role": "value.precipitation.hour",
+      "type": "number",
+      "unit": "mm",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.precip_1hr_metric"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451322,
+    "_id": "weatherunderground.0.forecast.current.precipitationHour",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.pressure": {
+    "type": "state",
+    "common": {
+      "name": "Air pressure (mbar)",
+      "role": "value.pressure",
+      "type": "number",
+      "unit": "mbar",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.pressure_mb"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451320,
+    "_id": "weatherunderground.0.forecast.current.pressure",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.relativeHumidity": {
+    "type": "state",
+    "common": {
+      "name": "Relative humidity",
+      "role": "value.humidity",
+      "type": "number",
+      "unit": "%",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.relative_humidity"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451316,
+    "_id": "weatherunderground.0.forecast.current.relativeHumidity",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.solarRadiation": {
+    "type": "state",
+    "common": {
+      "name": "Solar radiation",
+      "role": "value.radiation",
+      "type": "number",
+      "unit": "w/m2",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.solarradiation"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451321,
+    "_id": "weatherunderground.0.forecast.current.solarRadiation",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.temp": {
+    "type": "state",
+    "common": {
+      "name": "Temperature",
+      "role": "value.temperature",
+      "type": "number",
+      "unit": "°C",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.temp_c"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451312,
+    "_id": "weatherunderground.0.forecast.current.temp",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.visibility": {
+    "type": "state",
+    "common": {
+      "name": "Visibility",
+      "role": "value.distance.visibility",
+      "type": "number",
+      "unit": "km",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.visibility_km"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451315,
+    "_id": "weatherunderground.0.forecast.current.visibility",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.weather": {
+    "type": "state",
+    "common": {
+      "name": "Weather (engl.)",
+      "role": "weather.state",
+      "type": "string",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.weather"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451311,
+    "_id": "weatherunderground.0.forecast.current.weather",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.wind": {
+    "type": "state",
+    "common": {
+      "name": "Wind speed",
+      "role": "value.speed.wind",
+      "type": "number",
+      "unit": "km/h",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.wind_kph"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451318,
+    "_id": "weatherunderground.0.forecast.current.wind",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.windChill": {
+    "type": "state",
+    "common": {
+      "name": "Windchill",
+      "role": "value.temperature.windchill",
+      "type": "number",
+      "unit": "°C",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.windchill_c"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451314,
+    "_id": "weatherunderground.0.forecast.current.windChill",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.windDegrees": {
+    "type": "state",
+    "common": {
+      "name": "Wind direction Degrees",
+      "role": "value.direction.wind",
+      "type": "number",
+      "unit": "°",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.wind_degrees"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451317,
+    "_id": "weatherunderground.0.forecast.current.windDegrees",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.windDirection": {
+    "type": "state",
+    "common": {
+      "name": "Wind direction",
+      "role": "value.direction.wind",
+      "type": "string",
+      "unit": "",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.wind_degrees"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451318,
+    "_id": "weatherunderground.0.forecast.current.windDirection",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  },
+  "weatherunderground.0.forecast.current.windGust": {
+    "type": "state",
+    "common": {
+      "name": "Wind gust",
+      "role": "value.speed.wind.gust",
+      "type": "number",
+      "unit": "km/h",
+      "read": true,
+      "write": false
+    },
+    "native": {
+      "id": "current_observation.wind_gust_kph"
+    },
+    "from": "system.adapter.weatherunderground.0",
+    "user": "system.user.admin",
+    "ts": 1625152451319,
+    "_id": "weatherunderground.0.forecast.current.windGust",
+    "acl": {
+      "object": 1636,
+      "state": 1636,
+      "owner": "system.user.admin",
+      "ownerGroup": "system.group.administrator"
+    }
+  }
+}


### PR DESCRIPTION
I did try to understand an issue in lovelace and get accuweather detected as weatherForecast device (see PR in accuweather repository). 

For this I wrote tests using the three weather adapters I had installed on my system ( accuweather, dasWetter and weatherunderground). No functional update (just removed a surplus space in index.js). Feel free to merge, if you like the tests.