### PR TITLE
Weather device update

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,8 +169,10 @@ function ChannelDetector() {
                 {role: /^weather.state$|^weather.state.forecast.0$/,                 indicator: false, type: 'string',  name: 'STATE',         required: false, defaultRole: 'weather.state.forecast.0'},
                 {role: /^value.temperature$|^value.temperature.forecast.0$/,         indicator: false, type: 'number',  name: 'TEMP',          required: false, defaultRole: 'value.temperature.forecast.0'},
                 {role: /^value.pressure$/,                                           indicator: false, type: 'number',  name: 'PRESSURE',      required: false, defaultRole: 'weather.icon.forecast.0'},
-
                 {role: /^value.humidity$|value.humidity.forecast.0$/,                indicator: false, type: 'number',  name: 'HUMIDITY',      required: false, defaultRole: 'value.humidity.forecast.0'},
+                
+                {role: /^time.sunrise$|^time.sunrise.forecast.0$/,                   indicator: false, type: 'string',  name: 'TIME_SUNRISE',  required: false, defaultRole: 'time.sunrise'},
+                {role: /^time.sunset$|^time.sunset.forecast.0$/,                     indicator: false, type: 'string',  name: 'TIME_SUNSET',   required: false, defaultRole: 'time.sunset'},
 
                 {role: /^value.temperature.windchill$|^value.temperature.windchill.forecast.0$/, indicator: false, type: 'number',  name: 'WIND_CHILL',    required: false, defaultRole: 'value.temperature.windchill.forecast.0'},
                 {role: /^value.temperature.feelslike$|^value.temperature.feelslike.forecast.0$/, indicator: false, type: 'number',  name: 'FEELS_LIKE',    required: false, defaultRole: 'value.temperature.feelslike.forecast.0'},


### PR DESCRIPTION
Added time of sunrise and sunset that could be obtained from Accuweather adapter that was updated by @Garfonso to be detected as standard WeatherForecast device.
Works with custom accuweather card in lovelace. 
