### PR TITLE
Fire and flood

### DIFF
--- a/index.js
+++ b/index.js
@@ -557,7 +557,7 @@ function ChannelDetector() {
         },
         fireAlarm: {
             states: [
-                {role: /^state(\.alarm)?\.fire$|^sensor(\.alarm)?\.fire/,                        indicator: false, type: 'boolean', name: 'ACTUAL',     required: true, defaultRole: 'sensor.alarm.fire', defaultChannelRole: 'sensor.alarm.fire'},
+                {role: /^(state|sensor|indicator)(\.alarm)?\.fire$/,                        indicator: false, type: 'boolean', name: 'ACTUAL',     required: true, defaultRole: 'sensor.alarm.fire', defaultChannelRole: 'sensor.alarm.fire'},
                 // optional
                 SharedPatterns.unreach,
                 SharedPatterns.lowbat,
@@ -569,7 +569,7 @@ function ChannelDetector() {
         },
         floodAlarm: {
             states: [
-                {role: /^state(\.alarm)?\.flood$|^sensor(\.alarm)?\.flood/,                        indicator: false, type: 'boolean', name: 'ACTUAL',     required: true, defaultRole: 'sensor.alarm.flood', defaultChannelRole: 'sensor.alarm.flood'},
+                {role: /^(state|sensor|indicator)(\.alarm)?\.flood$/,                        indicator: false, type: 'boolean', name: 'ACTUAL',     required: true, defaultRole: 'sensor.alarm.flood', defaultChannelRole: 'sensor.alarm.flood'},
                 // optional
                 SharedPatterns.unreach,
                 SharedPatterns.lowbat,

--- a/index.js
+++ b/index.js
@@ -557,7 +557,7 @@ function ChannelDetector() {
         },
         fireAlarm: {
             states: [
-                {role: /^state(\.alarm)?\.fire$|^sensor(\.alarm)?\.fire/,                        indicator: false, type: 'boolean', name: 'ACTUAL',     required: true, channelRole: /^sensor(\.alarm)?\.fire$/, defaultRole: 'sensor.alarm.fire', defaultChannelRole: 'sensor.alarm.fire'},
+                {role: /^state(\.alarm)?\.fire$|^sensor(\.alarm)?\.fire/,                        indicator: false, type: 'boolean', name: 'ACTUAL',     required: true, defaultRole: 'sensor.alarm.fire', defaultChannelRole: 'sensor.alarm.fire'},
                 // optional
                 SharedPatterns.unreach,
                 SharedPatterns.lowbat,
@@ -569,7 +569,7 @@ function ChannelDetector() {
         },
         floodAlarm: {
             states: [
-                {role: /^state(\.alarm)?\.flood$|^sensor(\.alarm)?\.flood/,                        indicator: false, type: 'boolean', name: 'ACTUAL',     required: true, channelRole: /^sensor(\.alarm)?\.flood$/, defaultRole: 'sensor.alarm.flood', defaultChannelRole: 'sensor.alarm.flood'},
+                {role: /^state(\.alarm)?\.flood$|^sensor(\.alarm)?\.flood/,                        indicator: false, type: 'boolean', name: 'ACTUAL',     required: true, defaultRole: 'sensor.alarm.flood', defaultChannelRole: 'sensor.alarm.flood'},
                 // optional
                 SharedPatterns.unreach,
                 SharedPatterns.lowbat,


### PR DESCRIPTION
IMHO, the role regexes and type boolean restrictions should be sufficient to prevent false positives here. The channelRole seems to be used very sparsely. Especially for devices (i.e. no channel).

I also added the `indicator.alarm.fire|flood` roles to the regex. They are valid, too, following the stateroles-list. Although they seem a bit redundant. In the process, I noticed, that before `sensor.alarm.fireXYZ` would also be a valid role. I did remove that. Not 100% sure if that was intended before (`sensor.alarm.flooding` might be something that should be added to the regex, again, it was possible before but is not anymore, although `state.alarm.flooding` was forbidden before, too → so this was inconsistent). 

This would fix #38 and also allow Zigbee fire sensors to be automatically detected, for example.