### PR TITLE
allow mixed device->state and device->channel->state structures

### DIFF
--- a/src/ChannelDetector.ts
+++ b/src/ChannelDetector.ts
@@ -363,14 +363,11 @@ export class ChannelDetector {
                 return [id];
 
             case 'device':
-                const result = getAllStatesInDevice(keys, id);
-                if (result.length) {
-                    return result;
-                }
-
-                // if no states, it may be device without channels
-                return getAllStatesInChannel(keys, id);
-
+                //get states device->channel->state
+                const deviceStates = getAllStatesInDevice(keys, id);
+                //get states device->state
+                const channelStates = getAllStatesInChannel(keys, id);
+                return deviceStates.concat(channelStates);
             default:
                 // channel
                 return getAllStatesInChannel(keys, id);

--- a/src/ChannelDetector.ts
+++ b/src/ChannelDetector.ts
@@ -363,9 +363,9 @@ export class ChannelDetector {
                 return [id];
 
             case 'device':
-                //get states device->channel->state
+                // get states device->channel->state
                 const deviceStates = getAllStatesInDevice(keys, id);
-                //get states device->state
+                // get states device->state
                 const channelStates = getAllStatesInChannel(keys, id);
                 return deviceStates.concat(channelStates);
             default:


### PR DESCRIPTION
Currently, the structure `device->channel->state` is preferred and results are returned without looking at the states that are direct children of the device object (i.e. `device->state` structure). 

So a channel that does not contain anything useful for type-detector can prevent detection of a device if the useful states are directly children of the device object. IIRC wled is an example of that. 

I am not really sure what side effects this change might have. I searched through the devices I know, but could not find any obvious problems, and currently can't think of any.