### PR TITLE
[OFFICIAL RELEASE] 4.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,7 @@ if (controls) {
 -->
 
 ## Changelog
-
-### __WORK IN PROGRESS__
+### 4.1.1 (2024-12-15)
 -   (@Apollon77) Fixed default unit for Illuminance to "lux"
 -   (@Apollon77) Added Low-Battery state for switch to be consistent with other devices
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.type-detector",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.type-detector",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "devDependencies": {
         "@alcalzone/release-script": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.type-detector",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Detects devices in ioBroker for Material, Google home, Homekit, ...",
   "author": {
     "name": "bluefox",


### PR DESCRIPTION
-   (@Apollon77) Fixed default unit for Illuminance to "lux"
-   (@Apollon77) Added Low-Battery state for switch to be consistent with other devices