### PR TITLE
add default role to saturation and remove from ct

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -192,7 +192,7 @@ In [brackets] is given the class name of device.
 | * | CIE             | level.color.cie               |      | string  | W  |     |      | `/^level\.color\.cie$/`                                                      |
 |   | DIMMER          | level.dimmer                  | %    | number  | W  |     |      | `/^level\.dimmer$/`                                                          |
 |   | BRIGHTNESS      |                               | %    | number  | W  |     |      | `/^level\.brightness$/`                                                      |
-|   | SATURATION      |                               |      | number  | W  |     |      | `/^level\.color\.saturation$/`                                               |
+|   | SATURATION      | level.color.saturation        | %    | number  | W  |     |      | `/^level\.color\.saturation$/`                                               |
 |   | TEMPERATURE     | level.color.temperature       | °K   | number  | W  |     |      | `/^level\.color\.temperature$/`                                              |
 |   | ON              | switch.light                  |      | boolean | W  |     |      | `/^switch(\.light)?$/`                                                       |
 |   | ON_ACTUAL       | sensor.light                  |      | boolean | -  |     |      | `/^(state｜switch｜sensor)\.light｜switch$/`                                    |
@@ -216,7 +216,6 @@ In [brackets] is given the class name of device.
 | * | TEMPERATURE     | level.color.temperature       | °K   | number  | W  |     |      | `/^level\.color\.temperature$/`                                              |
 |   | DIMMER          | level.dimmer                  | %    | number  | W  |     |      | `/^level\.dimmer$/`                                                          |
 |   | BRIGHTNESS      |                               |      | number  | W  |     |      | `/^level\.brightness$/`                                                      |
-|   | SATURATION      |                               |      | number  | W  |     |      | `/^level\.color\.saturation$/`                                               |
 |   | ON              | switch.light                  |      | boolean | W  |     |      | `/^switch\.light$/`                                                          |
 |   | ON              |                               |      | boolean | W  |     |      | `/^switch$/`                                                                 |
 |   | ON_ACTUAL       | sensor.light                  |      | boolean | -  |     |      | `/^(state｜switch｜sensor)\.light｜switch$/`                                    |
@@ -308,7 +307,7 @@ In [brackets] is given the class name of device.
 | * | HUE             | level.color.hue               | °    | number  | W  |     |      | `/^level\.color\.hue$/`                                                      |
 |   | DIMMER          | level.dimmer                  | %    | number  | W  |     |      | `/^level\.dimmer$/`                                                          |
 |   | BRIGHTNESS      |                               |      | number  | W  |     |      | `/^level\.brightness$/`                                                      |
-|   | SATURATION      |                               |      | number  | W  |     |      | `/^level\.color\.saturation$/`                                               |
+|   | SATURATION      | level.color.saturation        | %    | number  | W  |     |      | `/^level\.color\.saturation$/`                                               |
 |   | TEMPERATURE     | level.color.temperature       | °K   | number  | W  |     |      | `/^level\.color\.temperature$/`                                              |
 |   | ON              | switch.light                  |      | boolean | W  |     |      | `/^switch\.light$/`                                                          |
 |   | ON              |                               |      | boolean | W  |     |      | `/^switch$/`                                                                 |
@@ -502,7 +501,7 @@ In [brackets] is given the class name of device.
 |   | WHITE           | level.color.white             |      | number  | W  |     |      | `/^level\.color\.white$/`                                                    |
 |   | DIMMER          | level.dimmer                  | %    | number  | W  |     |      | `/^level\.dimmer$/`                                                          |
 |   | BRIGHTNESS      |                               |      | number  | W  |     |      | `/^level\.brightness$/`                                                      |
-|   | SATURATION      |                               |      | number  | W  |     |      | `/^level\.color\.saturation$/`                                               |
+|   | SATURATION      | level.color.saturation        | %    | number  | W  |     |      | `/^level\.color\.saturation$/`                                               |
 |   | TEMPERATURE     | level.color.temperature       | °K   | number  | W  |     |      | `/^level\.color\.temperature$/`                                              |
 |   | ON              | switch.light                  |      | boolean | W  |     |      | `/^switch\.light$/`                                                          |
 |   | ON              |                               |      | boolean | W  |     |      | `/^switch$/`                                                                 |
@@ -527,7 +526,7 @@ In [brackets] is given the class name of device.
 | * | RGB             | level.color.rgb               |      | string  | W  |     |      | `/^level\.color\.rgb$/`                                                      |
 |   | DIMMER          | level.dimmer                  | %    | number  | W  |     |      | `/^level\.dimmer$/`                                                          |
 |   | BRIGHTNESS      |                               | %    | number  | W  |     |      | `/^level\.brightness$/`                                                      |
-|   | SATURATION      |                               |      | number  | W  |     |      | `/^level\.color\.saturation$/`                                               |
+|   | SATURATION      | level.color.saturation        | %    | number  | W  |     |      | `/^level\.color\.saturation$/`                                               |
 |   | TEMPERATURE     | level.color.temperature       | °K   | number  | W  |     |      | `/^level\.color\.temperature$/`                                              |
 |   | ON              | switch.light                  |      | boolean | W  |     |      | `/^switch\.light$/`                                                          |
 |   | ON              |                               |      | boolean | W  |     |      | `/^switch$/`                                                                 |
@@ -552,7 +551,7 @@ In [brackets] is given the class name of device.
 | * | RGBW            | level.color.rgbw              |      | string  | W  |     |      | `/^level\.color\.rgbw$/`                                                     |
 |   | DIMMER          | level.dimmer                  | %    | number  | W  |     |      | `/^level\.dimmer$/`                                                          |
 |   | BRIGHTNESS      |                               | %    | number  | W  |     |      | `/^level\.brightness$/`                                                      |
-|   | SATURATION      |                               |      | number  | W  |     |      | `/^level\.color\.saturation$/`                                               |
+|   | SATURATION      | level.color.saturation        | %    | number  | W  |     |      | `/^level\.color\.saturation$/`                                               |
 |   | TEMPERATURE     | level.color.temperature       | °K   | number  | W  |     |      | `/^level\.color\.temperature$/`                                              |
 |   | ON              | switch.light                  |      | boolean | W  |     |      | `/^switch\.light$/`                                                          |
 |   | ON              |                               |      | boolean | W  |     |      | `/^switch$/`                                                                 |

--- a/src/TypePatterns.ts
+++ b/src/TypePatterns.ts
@@ -833,6 +833,8 @@ export const patterns: { [key: string]: InternalPatternControl } = {
                 write: true,
                 name: 'SATURATION',
                 required: false,
+                defaultRole: 'level.color.saturation',
+                defaultUnit: '%',
             },
             {
                 role: /^level\.color\.temperature$/,
@@ -928,6 +930,8 @@ export const patterns: { [key: string]: InternalPatternControl } = {
                 write: true,
                 name: 'SATURATION',
                 required: false,
+                defaultRole: 'level.color.saturation',
+                defaultUnit: '%',
             },
             {
                 role: /^level\.color\.temperature$/,
@@ -1023,6 +1027,8 @@ export const patterns: { [key: string]: InternalPatternControl } = {
                 write: true,
                 name: 'SATURATION',
                 required: false,
+                defaultRole: 'level.color.saturation',
+                defaultUnit: '%',
             },
             {
                 role: /^level\.color\.temperature$/,
@@ -1118,6 +1124,8 @@ export const patterns: { [key: string]: InternalPatternControl } = {
                 write: true,
                 name: 'SATURATION',
                 required: false,
+                defaultRole: 'level.color.saturation',
+                defaultUnit: '%',
             },
             {
                 role: /^level\.color\.temperature$/,
@@ -1206,6 +1214,8 @@ export const patterns: { [key: string]: InternalPatternControl } = {
                 write: true,
                 name: 'SATURATION',
                 required: false,
+                defaultRole: 'level.color.saturation',
+                defaultUnit: '%',
             },
             {
                 role: /^level\.color\.temperature$/,
@@ -1292,14 +1302,6 @@ export const patterns: { [key: string]: InternalPatternControl } = {
                 type: StateType.Number,
                 write: true,
                 name: 'BRIGHTNESS',
-                required: false,
-            },
-            {
-                role: /^level\.color\.saturation$/,
-                indicator: false,
-                type: StateType.Number,
-                write: true,
-                name: 'SATURATION',
                 required: false,
             },
             {

--- a/src/TypePatterns.ts
+++ b/src/TypePatterns.ts
@@ -1305,6 +1305,14 @@ export const patterns: { [key: string]: InternalPatternControl } = {
                 required: false,
             },
             {
+                role: /^level\.color\.saturation$/,
+                indicator: false,
+                type: StateType.Number,
+                write: true,
+                name: 'SATURATION',
+                required: false,
+            },
+            {
                 role: /^switch\.light$/,
                 indicator: false,
                 type: StateType.Boolean,


### PR DESCRIPTION
Default role is used by devices-adapter to identify it as a state worth adding. Also, without default role, created aliases won't be detected by type-detector and go missing. So default role is necessary. And we already have a role, so lets use it.

I also added the default unit of % because saturation usually is some kind of "% color saturation against gray".

I removed saturation from ct = lamp with color temperature, since from my understanding saturation refers to color... not sure why it was there in the first place? I'm not sure what kind of "saturation" there is on a color temperature lamp... But I'm not 100% sure with this one. 

This should fix #https://github.com/ioBroker/ioBroker.devices/issues/362 when devices is rebuild against a newer version of type-detector (working on that one)