### PR TITLE
[OFFICIAL RELEASE] 4.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ if (controls) {
 -->
 
 ## Changelog
-### **WORK IN PROGRESS**
+### 4.3.0 (2025-04-21)
 -   (@GermanBluefox) Added default role for `image`
 -   (@GermanBluefox) Added exported type `ExternalDetectorState`
 -   (@Apollon77) Removed "Saturation" states from non-Hue light device types to not block that state for detection

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.type-detector",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.type-detector",
-      "version": "4.2.1",
+      "version": "4.3.0",
       "license": "MIT",
       "devDependencies": {
         "@alcalzone/release-script": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.type-detector",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "description": "Detects devices in ioBroker for Material, Google home, Homekit, ...",
   "author": {
     "name": "bluefox",


### PR DESCRIPTION
-   (@GermanBluefox) Added default role for `image`
-   (@GermanBluefox) Added exported type `ExternalDetectorState`
-   (@Apollon77) Removed "Saturation" states from non-Hue light device types to not block that state for detection
-   (@Apollon77) Added default unit "%" to volume definitions
-   (@Apollon77) Combined some duplicate state definitions
-   (@Apollon77) Adjusted Airconditioner Mode definition
-   (@Apollon77) Optimized Detection logic in several places
-   (@Apollon77) Consider allowed/excluded types when returning cached results
-   (@Apollon77) Added "detectParent" mode to always search up in the objects to a device or channel when detecting
-   (@Apollon77) Added "prioritizedTypes" property for options to allow type detection prioritization
-   (@GermanBluefox) Improved documentation