### PR TITLE
 Added detection option `limitTypesToOneOf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ if (controls) {
 -->
 
 ## Changelog
+
+### __WORK IN PROGRESS__
+-   (@Apollon77) Added detection option `limitTypesToOneOf` to define limiting sets of detected types
+
 ### 4.3.1 (2025-04-22)
 -   (@GermanBluefox) Rename type `location_one` to `locationOne`
 

--- a/src/ChannelDetector.ts
+++ b/src/ChannelDetector.ts
@@ -330,12 +330,13 @@ export class ChannelDetector {
     /**
      * Tries to find a device or channel (as fallback) where the state is in
      */
-    private static findParentChannelOrDevice(objects: Record<string, ioBroker.Object>, id: string): string | null {
+    private static findParentChannelOrDevice(objects: Record<string, ioBroker.Object>, id: string): string | undefined {
         if (!objects[id]) {
             // Object does not exist
-            return null;
+            return;
         }
         const parts = id.split('.');
+        const origId = id;
 
         if (objects[id].type === 'state') {
             // a state needs to be in a channel, device, folder or such, so check the level above
@@ -348,7 +349,7 @@ export class ChannelDetector {
         }
 
         const obj = objects[id];
-        if (obj.type === 'device') {
+        if (obj?.type === 'device') {
             // We found a device object, use this
             return id;
         }
@@ -357,7 +358,7 @@ export class ChannelDetector {
         const upperObj = objects[upperLevelObjectId];
         if (!upperObj) {
             // Ok not existing object, so we use the existing object from before
-            return id;
+            return obj ? id : origId;
         }
         if (upperObj.type === 'device' || parts.length <= 2) {
             // We found a device object, or ended already on instance level, use this
@@ -565,7 +566,7 @@ export class ChannelDetector {
             // looking for indicators and special states
             if (currentType !== 'device') {
                 // get device name
-                const deviceId = getParentId(id);
+                const deviceId = ChannelDetector.findParentChannelOrDevice(objects, id) ?? id;
                 if (
                     objects[deviceId] &&
                     (objects[deviceId].type === 'channel' || objects[deviceId].type === 'device')

--- a/src/types.ts
+++ b/src/types.ts
@@ -184,14 +184,20 @@ export interface DetectOptions {
     /** ID to detect of state, device or channel */
     id: string;
 
-    /** List of state names, that will be ignored. E.g., ['UNREACH_STICKY'] */
+    /** List of state names, that will be ignored. e.g., ['UNREACH_STICKY'] */
     ignoreIndicators?: string[];
 
-    /** List of allowed types. E.g., ['slider', 'rgbSingle'] */
+    /** List of allowed types. e.g., ['slider', 'rgbSingle'] */
     allowedTypes?: Types[];
 
-    /** List of excluded types. E.g., ['rgb', 'rgbSingle'] */
+    /** List of excluded types. e.g., ['rgb', 'rgbSingle'] */
     excludedTypes?: Types[];
+
+    /**
+     * List of types that when detected also limit other types,
+     * e.g. [[Types.light, Types.ct, Types.rgb, Types.rgbSingle, Types.rgbwSingle, Types.hue, Types.cie]] limits detection to one lighting type.
+     */
+    limitTypesToOneOf?: Types[][];
 
     /**
      * List of Types to prioritize before the others.
@@ -244,11 +250,15 @@ export interface DetectorContext {
     usedIds: string[];
     usedInCurrentDevice: string[];
     ignoreIndicators: string[];
-    result: PatternControl | null;
+    result?: PatternControl;
     pattern: Types;
     state: InternalDetectorState;
     ignoreEnums: boolean;
     sortedKeys: string[];
+}
+
+export interface MatchedDetectorContext extends Omit<DetectorContext, 'result'> {
+    result: PatternControl;
 }
 
 export interface InternalPatternControl {

--- a/test/detector.typescript.test.js
+++ b/test/detector.typescript.test.js
@@ -711,6 +711,39 @@ describe(`${name} Test Detector`, () => {
             ON: 'zigbee.0.AAAAAAA.state',
         });
 
+        // We still secondary detect other types, but only the minimal states
+        validate(controls[1], Types.rgb, {
+            RED: 'zigbee.0.AAAAAAA.color_rgb.r',
+            GREEN: 'zigbee.0.AAAAAAA.color_rgb.g',
+            BLUE: 'zigbee.0.AAAAAAA.color_rgb.b',
+        });
+
+        // We still secondary detect other types, but only the minimal states
+        validate(controls[2], Types.rgbSingle, {
+            RGB: 'zigbee.0.AAAAAAA.color',
+        });
+
+        done();
+    });
+
+    it(`${name} Must detect hue light only when device is used with adjusted prioritization and limitation`, done => {
+        const controls = detect('./zigbee.0.AAAAAAA.json', {
+            id: 'zigbee.0.AAAAAAA',
+            prioritizedTypes: [[Types.hue, Types.rgb]],
+            limitTypesToOneOf: [[Types.rgb, Types.rgbSingle, Types.rgbwSingle, Types.hue]]
+        });
+
+        validate(controls[0], Types.hue, {
+            HUE: 'zigbee.0.AAAAAAA.color_hs.hue',
+            SATURATION: 'zigbee.0.AAAAAAA.color_hs.saturation',
+            DIMMER: 'zigbee.0.AAAAAAA.brightness',
+            TEMPERATURE: 'zigbee.0.AAAAAAA.colortemp',
+            ON: 'zigbee.0.AAAAAAA.state',
+        });
+
+        expect(controls[1].type === Types.rgb).to.be.false;
+        expect(controls[2].type === Types.rgbSingle).to.be.false;
+
         done();
     });
 });


### PR DESCRIPTION
This allows to e.g. make sure that only one lighting type is detected instead of multiple just because additional states would be there