### PR TITLE
Enhance multi detection

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -821,7 +821,7 @@ Just sensor if alarm should be shown.
 |   | DOW                    | dayofweek.forecast.0                   |       | string |     |       | `/^dayofweek$｜^dayofweek.forecast.0$/`                                     |
 |   | STATE                  | weather.state.forecast.0               |       | string |     |       | `/^weather.state$｜^weather.state.forecast.0$/`                             |
 |   | TEMP                   | value.temperature.forecast.0           |       | number |     |       | `/^value.temperature$｜^value.temperature.forecast.0$/`                     |
-|   | PRESSURE               | weather.icon.forecast.0                |       | number |     |       | `/^value.pressure$/`                                                       |
+|   | PRESSURE               | value.pressure.forecast.0              |       | number |     |       | `/^value.pressure$/`                                                       |
 |   | HUMIDITY               | value.humidity.forecast.0              |       | number |     |       | `/^value.humidity$｜value.humidity.forecast.0$/`                            |
 |   | TIME_SUNRISE           | date.sunrise                           |       | string |     |       | `/^(?:date｜time).sunrise(?:.forecast\.0)?$/`                               |
 |   | TIME_SUNSET            | date.sunset                            |       | string |     |       | `/^(?:date｜time).sunset(?:.forecast\.0)?$/`                                |

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ if (controls) {
 -->
 
 ## Changelog
+### __WORK IN PROGRESS__
+-   (@Apollon77) Enhance detection logic when multiple states are detected on same pattern-state to favor ID, default-role and number-of-role-levels and not "state" roles
+
 ### 4.4.0 (2025-04-27)
 -   (@Apollon77) Added detection option `limitTypesToOneOf` to define limiting sets of detected types
 

--- a/src/typePatterns.ts
+++ b/src/typePatterns.ts
@@ -506,7 +506,7 @@ export const patterns: { [key: string]: InternalPatternControl } = {
                 type: StateType.Number,
                 name: 'PRESSURE',
                 required: false,
-                defaultRole: 'weather.icon.forecast.0',
+                defaultRole: 'value.pressure.forecast.0',
             },
             {
                 role: /^value.humidity$|value.humidity.forecast.0$/,

--- a/src/types.ts
+++ b/src/types.ts
@@ -255,6 +255,7 @@ export interface DetectorContext {
     state: InternalDetectorState;
     ignoreEnums: boolean;
     sortedKeys: string[];
+    favorId?: string;
 }
 
 export interface MatchedDetectorContext extends Omit<DetectorContext, 'result'> {

--- a/test/detector.typescript.test.js
+++ b/test/detector.typescript.test.js
@@ -277,8 +277,9 @@ describe(`${name} Test Detector`, () => {
             STATE: 'mihome-vacuum.0.info.state',
             PAUSE: 'mihome-vacuum.0.control.pauseResume',
             FILTER: 'mihome-vacuum.0.consumable.filter',
-            BRUSH: 'mihome-vacuum.0.consumable.side_brush',
+            BRUSH: 'mihome-vacuum.0.consumable.main_brush',
             SENSORS: 'mihome-vacuum.0.consumable.sensors',
+            SIDE_BRUSH: 'mihome-vacuum.0.consumable.side_brush',
         });
 
         done();
@@ -407,10 +408,10 @@ describe(`${name} Test Detector`, () => {
             TEMP_MIN: 'weatherunderground.0.forecast.0d.tempMin',
             TEMP_MAX: 'weatherunderground.0.forecast.0d.tempMax',
             PRECIPITATION_CHANCE: 'weatherunderground.0.forecast.0d.precipitationChance',
-            DATE: 'weatherunderground.0.forecast.current.observationTime',
-            STATE: 'weatherunderground.0.forecast.current.weather',
+            DATE: 'weatherunderground.0.forecast.0d.date',
+            STATE: 'weatherunderground.0.forecast.0d.state',
             PRESSURE: 'weatherunderground.0.forecast.current.pressure',
-            HUMIDITY: 'weatherunderground.0.forecast.current.relativeHumidity',
+            HUMIDITY: 'weatherunderground.0.forecast.0d.humidity',
             WIND_CHILL: 'weatherunderground.0.forecast.current.windChill',
         };
         const days = [1, 2, 3];
@@ -743,6 +744,259 @@ describe(`${name} Test Detector`, () => {
 
         expect(controls[1].type === Types.rgb).to.be.false;
         expect(controls[2].type === Types.rgbSingle).to.be.false;
+
+        done();
+    });
+
+    it('Must detect the window state with the role with more sublevels also when alphabetically comes first', done => {
+        const objects = {
+            'test.0.window': {
+                common: {
+                    name: 'window',
+                },
+                type: 'device',
+            },
+            'test.0.window.x-contact': {
+                common: {
+                    name: 'contact',
+                    type: 'boolean',
+                    role: 'state',
+                    read: true,
+                    write: false,
+                },
+                type: 'state',
+            },
+            'test.0.window.a-opened': {
+                common: {
+                    name: 'opened',
+                    type: 'boolean',
+                    role: 'sensor.window',
+                    read: true,
+                    write: false,
+                },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, {
+            id: 'test.0.window',
+            ignoreEnums: true
+        });
+
+        validate(controls[0], Types.window, {
+            ACTUAL: 'test.0.window.a-opened',
+        });
+
+        done();
+    });
+
+    it('Must detect the window state with the role without overwriting with more sublevels also when alphabetically comes last', done => {
+        const objects = {
+            'test.0.window': {
+                common: {
+                    name: 'window',
+                },
+                type: 'device',
+            },
+            'test.0.window.a-opened': {
+                common: {
+                    name: 'opened',
+                    type: 'boolean',
+                    role: 'sensor.window',
+                    read: true,
+                    write: false,
+                },
+                type: 'state',
+            },
+            'test.0.window.x-contact': {
+                common: {
+                    name: 'contact',
+                    type: 'boolean',
+                    role: 'state',
+                    read: true,
+                    write: false,
+                },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, {
+            id: 'test.0.window',
+            ignoreEnums: true
+        });
+
+        validate(controls[0], Types.window, {
+            ACTUAL: 'test.0.window.a-opened',
+        });
+
+        done();
+    });
+
+    it('Must detect the window state with the role other than state also when alphabetically comes first', done => {
+        const objects = {
+            'test.0.window': {
+                common: {
+                    name: 'window',
+                },
+                type: 'device',
+            },
+            'test.0.window.x-contact': {
+                common: {
+                    name: 'contact',
+                    type: 'boolean',
+                    role: 'sensor',
+                    read: true,
+                    write: false,
+                },
+                type: 'state',
+            },
+            'test.0.window.a-opened': {
+                common: {
+                    name: 'opened',
+                    type: 'boolean',
+                    role: 'state',
+                    read: true,
+                    write: false,
+                },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, {
+            id: 'test.0.window',
+            ignoreEnums: true
+        });
+
+        validate(controls[0], Types.window, {
+            ACTUAL: 'test.0.window.x-contact',
+        });
+
+        done();
+    });
+
+    it('Must detect the window state with last entry when same role', done => {
+        const objects = {
+            'test.0.window': {
+                common: {
+                    name: 'window',
+                },
+                type: 'device',
+            },
+            'test.0.window.a-opened': {
+                common: {
+                    name: 'opened',
+                    type: 'boolean',
+                    role: 'sensor',
+                    read: true,
+                    write: false,
+                },
+                type: 'state',
+            },
+            'test.0.window.x-contact': {
+                common: {
+                    name: 'contact',
+                    type: 'boolean',
+                    role: 'sensor',
+                    read: true,
+                    write: false,
+                },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, {
+            id: 'test.0.window',
+            ignoreEnums: true
+        });
+
+        validate(controls[0], Types.window, {
+            ACTUAL: 'test.0.window.x-contact',
+        });
+
+        done();
+    });
+
+    it('Must detect the favored state even with role not matching', done => {
+        const objects = {
+            'test.0.window': {
+                common: {
+                    name: 'window',
+                },
+                type: 'device',
+            },
+            'test.0.window.x-contact': {
+                common: {
+                    name: 'contact',
+                    type: 'boolean',
+                    role: 'state',
+                    read: true,
+                    write: false,
+                },
+                type: 'state',
+            },
+            'test.0.window.a-opened': {
+                common: {
+                    name: 'opened',
+                    type: 'boolean',
+                    role: 'sensor.window',
+                    read: true,
+                    write: false,
+                },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, {
+            id: 'test.0.window.x-contact',
+            ignoreEnums: true
+        });
+
+        validate(controls[0], Types.window, {
+            ACTUAL: 'test.0.window.x-contact',
+        });
+
+        done();
+    });
+
+    it('Must inore favored id when detecting via parent', done => {
+        const objects = {
+            'test.0.window': {
+                common: {
+                    name: 'window',
+                },
+                type: 'device',
+            },
+            'test.0.window.x-contact': {
+                common: {
+                    name: 'contact',
+                    type: 'boolean',
+                    role: 'state',
+                    read: true,
+                    write: false,
+                },
+                type: 'state',
+            },
+            'test.0.window.a-opened': {
+                common: {
+                    name: 'opened',
+                    type: 'boolean',
+                    role: 'sensor.window',
+                    read: true,
+                    write: false,
+                },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, {
+            id: 'test.0.window.x-contact',
+            detectParent: true,
+            ignoreEnums: true
+        });
+
+        validate(controls[0], Types.window, {
+            ACTUAL: 'test.0.window.a-opened',
+        });
 
         done();
     });


### PR DESCRIPTION
This change enhances the detection logic in case that a state could be matched multiple times by:
* if detection is not done via "detectParent" then the provided id wins if being detected
* if default Role matches to a state then this is favored
* Else only not empty roles are considered
* Else a role start starts with "state" looses against others
* Else number of levels of the roles are compared (more levels, ore detailed)
* A secondly detected state is only used when one of the above checks determined it as better

It also fixes one pattern bug and tests