### PR TITLE
fix: rename direction_enum detected state to DIRECTION_ENUM

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -107,50 +107,50 @@ Air conditioner with warming and cooling functions.
 
 Blinds, Shutter, Jalousie controlled by stop, up, down buttons. Position is unknown.
 
-| R | Name        | Role                          | Unit | Type    | Wr | Enum | Ind | Multi | Regex                                             |
-|---|-------------|-------------------------------|------|---------|----|------|-----|-------|---------------------------------------------------|
-| * | STOP        | button.stop.blind             |      | boolean | W  | E    |     |       | `/^(button｜action)\.stop(\.blind)?$/`             |
-| * | OPEN        | button.open.blind             |      | boolean | W  | E    |     |       | `/^(button｜action)\.open(\.blind)?$/`             |
-| * | CLOSE       | button.close.blind            |      | boolean | W  | E    |     |       | `/^(button｜action)\.close(\.blind)?$/`            |
-|   | TILT_SET    | level.tilt                    |      | number  | W  | E    |     |       | `/^level\.tilt$/`                                 |
-|   | TILT_ACTUAL | value.tilt                    |      | number  |    | E    |     |       | `/^value\.tilt$/`                                 |
-|   | TILT_STOP   | button.stop.tilt              |      | boolean | W  | E    |     |       | `/^(button｜action)\.stop\.tilt$/`                 |
-|   | TILT_OPEN   | button.open.tilt              |      | boolean | W  | E    |     |       | `/^(button｜action)\.open\.tilt$/`                 |
-|   | TILT_CLOSE  | button.close.tilt             |      | boolean | W  | E    |     |       | `/^(button｜action)\.close\.tilt$/`                |
-|   | DIRECTION   | indicator.direction           |      | boolean |    |      | X   |       | `/^indicator\.direction$/`                        |
-|   | DIRECTION   | value.direction               |      | number  |    |      |     |       | `/^(indicator｜value)\.direction$/`                |
-|   | WORKING     | indicator.working             |      |         |    |      | X   |       | `/^indicator\.working$/`                          |
-|   | UNREACH     | indicator.maintenance.unreach |      | boolean |    |      | X   |       | `/^indicator(\.maintenance)?\.unreach$/`          |
-|   | LOWBAT      | indicator.maintenance.lowbat  |      | boolean |    |      | X   |       | `/^indicator(\.maintenance)?\.(lowbat｜battery)$/` |
-|   | MAINTAIN    | indicator.maintenance         |      | boolean |    |      | X   |       | `/^indicator\.maintenance$/`                      |
-|   | ERROR       | indicator.error               |      |         |    |      | X   |       | `/^indicator\.error$/`                            |
-|   | BATTERY     | value.battery                 | %    | number  | -  |      |     |       | `/^value\.battery$/`                              |
+| R | Name           | Role                          | Unit | Type    | Wr | Enum | Ind | Multi | Regex                                             |
+|---|----------------|-------------------------------|------|---------|----|------|-----|-------|---------------------------------------------------|
+| * | STOP           | button.stop.blind             |      | boolean | W  | E    |     |       | `/^(button｜action)\.stop(\.blind)?$/`             |
+| * | OPEN           | button.open.blind             |      | boolean | W  | E    |     |       | `/^(button｜action)\.open(\.blind)?$/`             |
+| * | CLOSE          | button.close.blind            |      | boolean | W  | E    |     |       | `/^(button｜action)\.close(\.blind)?$/`            |
+|   | TILT_SET       | level.tilt                    |      | number  | W  | E    |     |       | `/^level\.tilt$/`                                 |
+|   | TILT_ACTUAL    | value.tilt                    |      | number  |    | E    |     |       | `/^value\.tilt$/`                                 |
+|   | TILT_STOP      | button.stop.tilt              |      | boolean | W  | E    |     |       | `/^(button｜action)\.stop\.tilt$/`                 |
+|   | TILT_OPEN      | button.open.tilt              |      | boolean | W  | E    |     |       | `/^(button｜action)\.open\.tilt$/`                 |
+|   | TILT_CLOSE     | button.close.tilt             |      | boolean | W  | E    |     |       | `/^(button｜action)\.close\.tilt$/`                |
+|   | DIRECTION      | indicator.direction           |      | boolean |    |      | X   |       | `/^indicator\.direction$/`                        |
+|   | DIRECTION_ENUM | value.direction               |      | number  |    |      |     |       | `/^(indicator｜value)\.direction$/`                |
+|   | WORKING        | indicator.working             |      |         |    |      | X   |       | `/^indicator\.working$/`                          |
+|   | UNREACH        | indicator.maintenance.unreach |      | boolean |    |      | X   |       | `/^indicator(\.maintenance)?\.unreach$/`          |
+|   | LOWBAT         | indicator.maintenance.lowbat  |      | boolean |    |      | X   |       | `/^indicator(\.maintenance)?\.(lowbat｜battery)$/` |
+|   | MAINTAIN       | indicator.maintenance         |      | boolean |    |      | X   |       | `/^indicator\.maintenance$/`                      |
+|   | ERROR          | indicator.error               |      |         |    |      | X   |       | `/^indicator\.error$/`                            |
+|   | BATTERY        | value.battery                 | %    | number  | -  |      |     |       | `/^value\.battery$/`                              |
 
 
 ### Blinds or Shutter [blinds]
 
 Blinds, Shutter, Jalousie controlled by state with percent.
 
-| R | Name        | Role                          | Unit | Type    | Wr | Enum | Ind | Multi | Regex                                             |
-|---|-------------|-------------------------------|------|---------|----|------|-----|-------|---------------------------------------------------|
-| * | SET         | level.blind                   | %    | number  | W  | E    |     |       | `/^level(\.blind)?$/`                             |
-|   | ACTUAL      | value.blind                   | %    | number  |    | E    |     |       | `/^value(\.blind)?$/`                             |
-|   | STOP        | button.stop.blind             |      | boolean | W  | E    |     |       | `/^(button｜action)\.stop(\.blind)?$/`             |
-|   | OPEN        | button.open.blind             |      | boolean | W  | E    |     |       | `/^(button｜action)\.open(\.blind)?$/`             |
-|   | CLOSE       | button.close.blind            |      | boolean | W  | E    |     |       | `/^(button｜action)\.close(\.blind)?$/`            |
-|   | TILT_SET    | level.tilt                    |      | number  | W  | E    |     |       | `/^level(\.open)?\.tilt$/`                        |
-|   | TILT_ACTUAL | value.tilt                    |      | number  |    | E    |     |       | `/^value(\.open)?\.tilt$/`                        |
-|   | TILT_STOP   | button.stop.tilt              |      | boolean | W  | E    |     |       | `/^(button｜action)\.stop\.tilt$/`                 |
-|   | TILT_OPEN   | button.open.tilt              |      | boolean | W  | E    |     |       | `/^(button｜action)\.open\.tilt$/`                 |
-|   | TILT_CLOSE  | button.close.tilt             |      | boolean | W  | E    |     |       | `/^(button｜action)\.close\.tilt$/`                |
-|   | DIRECTION   | indicator.direction           |      | boolean |    |      | X   |       | `/^indicator\.direction$/`                        |
-|   | DIRECTION   | value.direction               |      | number  |    |      |     |       | `/^(indicator｜value)\.direction$/`                |
-|   | WORKING     | indicator.working             |      |         |    |      | X   |       | `/^indicator\.working$/`                          |
-|   | UNREACH     | indicator.maintenance.unreach |      | boolean |    |      | X   |       | `/^indicator(\.maintenance)?\.unreach$/`          |
-|   | LOWBAT      | indicator.maintenance.lowbat  |      | boolean |    |      | X   |       | `/^indicator(\.maintenance)?\.(lowbat｜battery)$/` |
-|   | MAINTAIN    | indicator.maintenance         |      | boolean |    |      | X   |       | `/^indicator\.maintenance$/`                      |
-|   | ERROR       | indicator.error               |      |         |    |      | X   |       | `/^indicator\.error$/`                            |
-|   | BATTERY     | value.battery                 | %    | number  | -  |      |     |       | `/^value\.battery$/`                              |
+| R | Name           | Role                          | Unit | Type    | Wr | Enum | Ind | Multi | Regex                                             |
+|---|----------------|-------------------------------|------|---------|----|------|-----|-------|---------------------------------------------------|
+| * | SET            | level.blind                   | %    | number  | W  | E    |     |       | `/^level(\.blind)?$/`                             |
+|   | ACTUAL         | value.blind                   | %    | number  |    | E    |     |       | `/^value(\.blind)?$/`                             |
+|   | STOP           | button.stop.blind             |      | boolean | W  | E    |     |       | `/^(button｜action)\.stop(\.blind)?$/`             |
+|   | OPEN           | button.open.blind             |      | boolean | W  | E    |     |       | `/^(button｜action)\.open(\.blind)?$/`             |
+|   | CLOSE          | button.close.blind            |      | boolean | W  | E    |     |       | `/^(button｜action)\.close(\.blind)?$/`            |
+|   | TILT_SET       | level.tilt                    |      | number  | W  | E    |     |       | `/^level(\.open)?\.tilt$/`                        |
+|   | TILT_ACTUAL    | value.tilt                    |      | number  |    | E    |     |       | `/^value(\.open)?\.tilt$/`                        |
+|   | TILT_STOP      | button.stop.tilt              |      | boolean | W  | E    |     |       | `/^(button｜action)\.stop\.tilt$/`                 |
+|   | TILT_OPEN      | button.open.tilt              |      | boolean | W  | E    |     |       | `/^(button｜action)\.open\.tilt$/`                 |
+|   | TILT_CLOSE     | button.close.tilt             |      | boolean | W  | E    |     |       | `/^(button｜action)\.close\.tilt$/`                |
+|   | DIRECTION      | indicator.direction           |      | boolean |    |      | X   |       | `/^indicator\.direction$/`                        |
+|   | DIRECTION_ENUM | value.direction               |      | number  |    |      |     |       | `/^(indicator｜value)\.direction$/`                |
+|   | WORKING        | indicator.working             |      |         |    |      | X   |       | `/^indicator\.working$/`                          |
+|   | UNREACH        | indicator.maintenance.unreach |      | boolean |    |      | X   |       | `/^indicator(\.maintenance)?\.unreach$/`          |
+|   | LOWBAT         | indicator.maintenance.lowbat  |      | boolean |    |      | X   |       | `/^indicator(\.maintenance)?\.(lowbat｜battery)$/` |
+|   | MAINTAIN       | indicator.maintenance         |      | boolean |    |      | X   |       | `/^indicator\.maintenance$/`                      |
+|   | ERROR          | indicator.error               |      |         |    |      | X   |       | `/^indicator\.error$/`                            |
+|   | BATTERY        | value.battery                 | %    | number  | -  |      |     |       | `/^value\.battery$/`                              |
 
 
 ### Button [button]
@@ -348,17 +348,17 @@ If water sensor senses water (true) or not (false).
 
 Control of the gates. You can open (true) or close (false) the gate. Optionally, the exact position could exist.
 
-| R | Name      | Role                          | Unit | Type    | Wr | Enum | Ind | Multi | Regex                                    |
-|---|-----------|-------------------------------|------|---------|----|------|-----|-------|------------------------------------------|
-| * | SET       | switch.gate                   |      | boolean | W  | E    |     |       | `/^switch(\.gate)?$/`                    |
-|   | ACTUAL    | value.blind                   | %    | number  |    | E    |     |       | `/^value(\.(position｜gate))?$/`          |
-|   | STOP      | button.stop                   |      | boolean | W  | E    |     |       | `/^(button｜action)\.stop$/`              |
-|   | DIRECTION | indicator.direction           |      | boolean |    |      | X   |       | `/^indicator\.direction$/`               |
-|   | DIRECTION | value.direction               |      | number  |    |      |     |       | `/^(indicator｜value)\.direction$/`       |
-|   | WORKING   | indicator.working             |      |         |    |      | X   |       | `/^indicator\.working$/`                 |
-|   | UNREACH   | indicator.maintenance.unreach |      | boolean |    |      | X   |       | `/^indicator(\.maintenance)?\.unreach$/` |
-|   | MAINTAIN  | indicator.maintenance         |      | boolean |    |      | X   |       | `/^indicator\.maintenance$/`             |
-|   | ERROR     | indicator.error               |      |         |    |      | X   |       | `/^indicator\.error$/`                   |
+| R | Name           | Role                          | Unit | Type    | Wr | Enum | Ind | Multi | Regex                                    |
+|---|----------------|-------------------------------|------|---------|----|------|-----|-------|------------------------------------------|
+| * | SET            | switch.gate                   |      | boolean | W  | E    |     |       | `/^switch(\.gate)?$/`                    |
+|   | ACTUAL         | value.blind                   | %    | number  |    | E    |     |       | `/^value(\.(position｜gate))?$/`          |
+|   | STOP           | button.stop                   |      | boolean | W  | E    |     |       | `/^(button｜action)\.stop$/`              |
+|   | DIRECTION      | indicator.direction           |      | boolean |    |      | X   |       | `/^indicator\.direction$/`               |
+|   | DIRECTION_ENUM | value.direction               |      | number  |    |      |     |       | `/^(indicator｜value)\.direction$/`       |
+|   | WORKING        | indicator.working             |      |         |    |      | X   |       | `/^indicator\.working$/`                 |
+|   | UNREACH        | indicator.maintenance.unreach |      | boolean |    |      | X   |       | `/^indicator(\.maintenance)?\.unreach$/` |
+|   | MAINTAIN       | indicator.maintenance         |      | boolean |    |      | X   |       | `/^indicator\.maintenance$/`             |
+|   | ERROR          | indicator.error               |      |         |    |      | X   |       | `/^indicator\.error$/`                   |
 
 
 ### Light with HUE color [hue]
@@ -523,20 +523,20 @@ GPS location, where longitude and latitude are stored in one state, like `longit
 
 Lock. Could be opened (true), closed (false) or opened completely by `OPEN` state.
 
-| R | Name       | Role                          | Unit | Type    | Wr | Ind | Multi | Regex                                             |
-|---|------------|-------------------------------|------|---------|----|-----|-------|---------------------------------------------------|
-| * | SET        | switch.lock                   |      | boolean | W  |     |       | `/^switch\.lock$/`                                |
-|   | ACTUAL     | state                         |      | boolean | -  |     |       | `/^state$/`                                       |
-|   | OPEN       | button                        |      | boolean | W  |     |       |                                                   |
-|   | DOOR_STATE | sensor.door                   |      | boolean | -  |     |       | `/^(state｜sensor)(\.door)?$/`                     |
-|   | DIRECTION  | indicator.direction           |      | boolean |    | X   |       | `/^indicator\.direction$/`                        |
-|   | DIRECTION  | value.direction               |      | number  |    |     |       | `/^(indicator｜value)\.direction$/`                |
-|   | WORKING    | indicator.working             |      |         |    | X   |       | `/^indicator\.working$/`                          |
-|   | UNREACH    | indicator.maintenance.unreach |      | boolean |    | X   |       | `/^indicator(\.maintenance)?\.unreach$/`          |
-|   | LOWBAT     | indicator.maintenance.lowbat  |      | boolean |    | X   |       | `/^indicator(\.maintenance)?\.(lowbat｜battery)$/` |
-|   | MAINTAIN   | indicator.maintenance         |      | boolean |    | X   |       | `/^indicator\.maintenance$/`                      |
-|   | ERROR      | indicator.error               |      |         |    | X   |       | `/^indicator\.error$/`                            |
-|   | BATTERY    | value.battery                 | %    | number  | -  |     |       | `/^value\.battery$/`                              |
+| R | Name           | Role                          | Unit | Type    | Wr | Ind | Multi | Regex                                             |
+|---|----------------|-------------------------------|------|---------|----|-----|-------|---------------------------------------------------|
+| * | SET            | switch.lock                   |      | boolean | W  |     |       | `/^switch\.lock$/`                                |
+|   | ACTUAL         | state                         |      | boolean | -  |     |       | `/^state$/`                                       |
+|   | OPEN           | button                        |      | boolean | W  |     |       |                                                   |
+|   | DOOR_STATE     | sensor.door                   |      | boolean | -  |     |       | `/^(state｜sensor)(\.door)?$/`                     |
+|   | DIRECTION      | indicator.direction           |      | boolean |    | X   |       | `/^indicator\.direction$/`                        |
+|   | DIRECTION_ENUM | value.direction               |      | number  |    |     |       | `/^(indicator｜value)\.direction$/`                |
+|   | WORKING        | indicator.working             |      |         |    | X   |       | `/^indicator\.working$/`                          |
+|   | UNREACH        | indicator.maintenance.unreach |      | boolean |    | X   |       | `/^indicator(\.maintenance)?\.unreach$/`          |
+|   | LOWBAT         | indicator.maintenance.lowbat  |      | boolean |    | X   |       | `/^indicator(\.maintenance)?\.(lowbat｜battery)$/` |
+|   | MAINTAIN       | indicator.maintenance         |      | boolean |    | X   |       | `/^indicator\.maintenance$/`                      |
+|   | ERROR          | indicator.error               |      |         |    | X   |       | `/^indicator\.error$/`                            |
+|   | BATTERY        | value.battery                 | %    | number  | -  |     |       | `/^value\.battery$/`                              |
 
 
 ### Media player [mediaPlayer]

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ if (controls) {
 -->
 
 ## Changelog
+### **WORK IN PROGRESS**
+-   (@Apollon77) BREAKING: Renamed the detected state name of the `direction_enum` shared pattern from `DIRECTION` to `DIRECTION_ENUM` to make it distinguishable from the boolean `direction` pattern. Affects the device types `blind`, `blindButtons`, `gate` and `lock`.
+
 ### 5.0.15 (2026-07-10)
 -   (@GermanBluefox) Added tank level to devices
 

--- a/src/typePatterns.ts
+++ b/src/typePatterns.ts
@@ -96,7 +96,7 @@ const SharedPatterns: {
         role: /^(indicator|value)\.direction$/, // some old adapters implement `indicator.direction` even for number types. So try to detect it too
         type: StateType.Number,
         notSingle: true,
-        name: 'DIRECTION',
+        name: 'DIRECTION_ENUM',
         required: false,
         defaultStates: { 0: 'None', 1: 'Up/Open', 2: 'Down/Close', 3: 'Unknown' },
         defaultRole: 'value.direction',

--- a/test/detector.typescript.test.js
+++ b/test/detector.typescript.test.js
@@ -635,8 +635,46 @@ describe(`${name} Test Detector`, () => {
             SET: 'hm-rpc.0.LEQ090XYZ.1.STATE',
             OPEN: 'hm-rpc.0.LEQ090XYZ.1.OPEN',
             DOOR_STATE: 'hm-rpc.0.LEQ090XYZ.1.DOOR_STATE',
-            DIRECTION: 'hm-rpc.0.LEQ090XYZ.1.DIRECTION',
+            DIRECTION_ENUM: 'hm-rpc.0.LEQ090XYZ.1.DIRECTION',
             ERROR: 'hm-rpc.0.LEQ090XYZ.1.ERROR',
+        });
+
+        done();
+    });
+
+    it(`${name} Must detect boolean and enum direction as separate states`, done => {
+        const objects = {
+            'test.0.Blind': {
+                common: { name: 'Blind' },
+                type: 'channel',
+            },
+            'test.0.Blind.level': {
+                common: { name: 'Level', type: 'number', read: true, write: true, role: 'level.blind' },
+                type: 'state',
+            },
+            'test.0.Blind.moving': {
+                common: { name: 'Moving', type: 'boolean', read: true, write: false, role: 'indicator.direction' },
+                type: 'state',
+            },
+            'test.0.Blind.direction': {
+                common: {
+                    name: 'Direction',
+                    type: 'number',
+                    read: true,
+                    write: false,
+                    role: 'value.direction',
+                    states: { 0: 'None', 1: 'Up', 2: 'Down', 3: 'Unknown' },
+                },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, { id: 'test.0.Blind' });
+
+        validate(controls[0], Types.blind, {
+            SET: 'test.0.Blind.level',
+            DIRECTION: 'test.0.Blind.moving',
+            DIRECTION_ENUM: 'test.0.Blind.direction',
         });
 
         done();


### PR DESCRIPTION
## Problem

The shared patterns `direction` and `direction_enum` both emitted a detected state named `DIRECTION`:

- `direction` — role `/^indicator\.direction$/`, `type: Boolean`, `indicator: true`, `notSingle: true`
- `direction_enum` — role `/^(indicator|value)\.direction$/`, `type: Number`, `notSingle: true`

Both are `notSingle` and both are included in `blind`, `blindButtons`, `gate` and `lock`. A device exposing both a boolean `indicator.direction` and a numeric `value.direction` therefore produced two detected states with the identical name `DIRECTION`. Consumers that map detected states to typed properties by name (e.g. ioBroker.matter) cannot tell them apart — a name-based lookup returns whichever comes first, so one property silently binds to the wrong object.

## Change

`direction_enum` now emits `DIRECTION_ENUM`. The boolean `direction` pattern keeps `DIRECTION`.

`DEVICES.md` is regenerated (`npm run build:doc`); beyond the renamed rows the diff is table column realignment caused by the longer name.

## Breaking change

Consumers keying on `DIRECTION` for the numeric direction state must read `DIRECTION_ENUM`. ioBroker.matter already reads `DIRECTION_ENUM` when present and falls back to `DIRECTION`, so it is unaffected.

## Not changed

The issue also notes that `direction_enum`'s role regex `/^(indicator|value)\.direction$/` overlaps `direction`'s `/^indicator\.direction$/`. That overlap is intentional and documented inline — some old adapters use `indicator.direction` for number states. The `type` discriminator (`Boolean` vs `Number`) keeps the two patterns from claiming the same state, so no change was made here.

## Tests

- Existing lock test updated to expect `DIRECTION_ENUM` (its `hm-rpc` direction state is numeric with role `indicator.direction`).
- New test builds a blind exposing both a boolean `indicator.direction` and a numeric `value.direction`, and asserts they resolve to two distinct states.

Verified by reverting the `typePatterns.ts` hunk and rebuilding: the new test fails with `Error: Failed checking DIRECTION_ENUM`. Full suite (46 tests) and `npm run lint` pass with the hunk restored.

Fixes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)