### PR TITLE
feat: add airQuality device type

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -36,6 +36,7 @@ In [brackets] is given the class name of a device.
 
 ### Content
 * [Air conditioner [airCondition]](#air-conditioner-aircondition)
+* [Air quality sensor [airQuality]](#air-quality-sensor-airquality)
 * [Blinds controlled only by buttons [blindButtons]](#blinds-controlled-only-by-buttons-blindbuttons)
 * [Blinds or Shutter [blinds]](#blinds-or-shutter-blinds)
 * [Button [button]](#button-button)
@@ -101,6 +102,47 @@ Air conditioner with warming and cooling functions.
 |   | UNREACH        | indicator.maintenance.unreach |      | boolean        |    | X   |       | `/^indicator(\.maintenance)?\.unreach$/` |
 |   | MAINTAIN       | indicator.maintenance         |      | boolean        |    | X   |       | `/^indicator\.maintenance$/`             |
 |   | ERROR          | indicator.error               |      |                |    | X   |       | `/^indicator\.error$/`                   |
+
+
+### Air quality sensor [airQuality]
+
+Air quality sensor with an overall index and optionally single pollutant concentrations, temperature, humidity and air pressure.
+
+| R | Name       | Role                          | Unit  | Type    | Wr | Ind | Multi | Regex                                             |
+|---|------------|-------------------------------|-------|---------|----|-----|-------|---------------------------------------------------|
+| * | AQI        | value.airquality              |       | number  | -  |     |       | `/^value\.airquality$/`                           |
+|   | POWER      | switch.power                  |       | boolean | W  |     |       | `/^switch(\.power)?$/`                            |
+|   | CO2        | value.co2                     | ppm   | number  | -  |     |       | `/^value\.co2$/`                                  |
+|   | CO2_LEVEL  | value.co2.level               |       | number  | -  |     |       | `/^value\.co2\.level$/`                           |
+|   | TVOC       | value.tvoc                    |       | number  | -  |     |       | `/^value\.tvoc$/`                                 |
+|   | TVOC_LEVEL | value.tvoc.level              |       | number  | -  |     |       | `/^value\.tvoc\.level$/`                          |
+|   | PM1        | value.pm1                     | µg/m³ | number  | -  |     |       | `/^value\.pm1$/`                                  |
+|   | PM1_LEVEL  | value.pm1.level               |       | number  | -  |     |       | `/^value\.pm1\.level$/`                           |
+|   | PM25       | value.pm25                    | µg/m³ | number  | -  |     |       | `/^value\.pm25$/`                                 |
+|   | PM25_LEVEL | value.pm25.level              |       | number  | -  |     |       | `/^value\.pm25\.level$/`                          |
+|   | PM10       | value.pm10                    | µg/m³ | number  | -  |     |       | `/^value\.pm10$/`                                 |
+|   | PM10_LEVEL | value.pm10.level              |       | number  | -  |     |       | `/^value\.pm10\.level$/`                          |
+|   | CO         | value.co                      | ppm   | number  | -  |     |       | `/^value\.co$/`                                   |
+|   | CO_LEVEL   | value.co.level                |       | number  | -  |     |       | `/^value\.co\.level$/`                            |
+|   | NO2        | value.no2                     |       | number  | -  |     |       | `/^value\.no2$/`                                  |
+|   | NO2_LEVEL  | value.no2.level               |       | number  | -  |     |       | `/^value\.no2\.level$/`                           |
+|   | O3         | value.o3                      |       | number  | -  |     |       | `/^value\.o3$/`                                   |
+|   | O3_LEVEL   | value.o3.level                |       | number  | -  |     |       | `/^value\.o3\.level$/`                            |
+|   | CH2O       | value.ch2o                    | µg/m³ | number  | -  |     |       | `/^value\.ch2o$/`                                 |
+|   | CH2O_LEVEL | value.ch2o.level              |       | number  | -  |     |       | `/^value\.ch2o\.level$/`                          |
+|   | RN         | value.rn                      | Bq/m³ | number  | -  |     |       | `/^value\.rn$/`                                   |
+|   | RN_LEVEL   | value.rn.level                |       | number  | -  |     |       | `/^value\.rn\.level$/`                            |
+|   | SO2        | value.so2                     |       | number  | -  |     |       | `/^value\.so2$/`                                  |
+|   | SO2_LEVEL  | value.so2.level               |       | number  | -  |     |       | `/^value\.so2\.level$/`                           |
+|   | PRESSURE   | value.pressure                | mbar  | number  | -  |     |       | `/^value\.pressure$/`                             |
+|   | ACTUAL     | value.temperature             | °C    | number  | -  |     |       | `/temperature(\..*)?$/`                           |
+|   | HUMIDITY   | value.humidity                | %     | number  | -  |     |       | `/humidity(\..*)?$/`                              |
+|   | WORKING    | indicator.working             |       |         |    | X   |       | `/^indicator\.working$/`                          |
+|   | UNREACH    | indicator.maintenance.unreach |       | boolean |    | X   |       | `/^indicator(\.maintenance)?\.unreach$/`          |
+|   | LOWBAT     | indicator.maintenance.lowbat  |       | boolean |    | X   |       | `/^indicator(\.maintenance)?\.(lowbat｜battery)$/` |
+|   | MAINTAIN   | indicator.maintenance         |       | boolean |    | X   |       | `/^indicator\.maintenance$/`                      |
+|   | ERROR      | indicator.error               |       |         |    | X   |       | `/^indicator\.error$/`                            |
+|   | BATTERY    | value.battery                 | %     | number  | -  |     |       | `/^value\.battery$/`                              |
 
 
 ### Blinds controlled only by buttons [blindButtons]

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ if (controls) {
 -->
 
 ## Changelog
+### **WORK IN PROGRESS**
+-   (@Apollon77) Added new device type `airQuality` for air quality sensors (Matter Air Quality Sensor / Air Purifier)
+
 ### 5.0.15 (2026-07-10)
 -   (@GermanBluefox) Added tank level to devices
 

--- a/lib/nameOfTypes.js
+++ b/lib/nameOfTypes.js
@@ -2,6 +2,7 @@ const NameOfTypes = {
     unknown: { label: 'unknown', description: 'Unknown type' },
 
     airCondition: { label: 'Air conditioner', description: 'Air conditioner with warming and cooling functions.' },
+    airQuality: { label: 'Air quality sensor', description: 'Air quality sensor with an overall index and optionally single pollutant concentrations, temperature, humidity and air pressure.' },
     blind: { label: 'Blinds or Shutter', description: 'Blinds, Shutter, Jalousie controlled by state with percent.' },
     blindButtons: { label: 'Blinds controlled only by buttons', description: 'Blinds, Shutter, Jalousie controlled by stop, up, down buttons. Position is unknown.' },
     button: { label: 'Button', description: 'Button that could be only pressed (command). It has no feedback, you can write only `true`.' },

--- a/src/typePatterns.ts
+++ b/src/typePatterns.ts
@@ -176,6 +176,43 @@ const ElectricityPatterns: { [id: string]: InternalDetectorState } = {
     },
 };
 
+const AIR_QUALITY_LEVEL_STATES = { 0: 'UNKNOWN', 1: 'LOW', 2: 'MEDIUM', 3: 'HIGH', 4: 'CRITICAL' };
+
+/**
+ * Builds the two optional states a pollutant can expose: the measured concentration and the qualitative level
+ * (Matter concentration-measurement clusters report `levelValue` next to `measuredValue`).
+ *
+ * @param name Emitted state name of the concentration, e.g. `PM25`. The level state is emitted as `<name>_LEVEL`.
+ * @param roleId Role id below `value.`, e.g. `pm25`, matching the ids of https://github.com/ioBroker/ioBroker.docs/pull/643
+ * @param defaultUnit Omitted where devices legitimately use more than one unit, so consumers keep the unit of the object
+ */
+function concentrationPatterns(name: string, roleId: string, defaultUnit?: string): InternalDetectorState[] {
+    return [
+        {
+            role: new RegExp(`^value\\.${roleId}$`),
+            indicator: false,
+            write: false,
+            type: StateType.Number,
+            searchInParent: true,
+            name,
+            required: false,
+            defaultRole: `value.${roleId}`,
+            defaultUnit,
+        },
+        {
+            role: new RegExp(`^value\\.${roleId}\\.level$`),
+            indicator: false,
+            write: false,
+            type: StateType.Number,
+            searchInParent: true,
+            name: `${name}_LEVEL`,
+            required: false,
+            defaultRole: `value.${roleId}.level`,
+            defaultStates: AIR_QUALITY_LEVEL_STATES,
+        },
+    ];
+}
+
 export const patterns: { [key: string]: InternalPatternControl } = {
     chart: {
         states: [{ objectType: 'chart', name: 'CHART' }],
@@ -2977,6 +3014,92 @@ export const patterns: { [key: string]: InternalPatternControl } = {
             SharedPatterns.battery,
         ],
         type: Types.buttonSensor,
+    },
+    airQuality: {
+        states: [
+            {
+                role: /^value\.airquality$/,
+                indicator: false,
+                write: false,
+                type: StateType.Number,
+                name: 'AQI',
+                required: true,
+                defaultRole: 'value.airquality',
+                defaultStates: {
+                    0: 'UNKNOWN',
+                    1: 'GOOD',
+                    2: 'FAIR',
+                    3: 'MODERATE',
+                    4: 'POOR',
+                    5: 'VERY_POOR',
+                    6: 'EXTREMELY_POOR',
+                },
+            },
+            // optional
+            {
+                role: /^switch(\.power)?$/,
+                indicator: false,
+                write: true,
+                type: StateType.Boolean,
+                searchInParent: true,
+                name: 'POWER',
+                required: false,
+                defaultRole: 'switch.power',
+            },
+            ...concentrationPatterns('CO2', 'co2', 'ppm'),
+            ...concentrationPatterns('TVOC', 'tvoc'),
+            ...concentrationPatterns('PM1', 'pm1', 'µg/m³'),
+            ...concentrationPatterns('PM25', 'pm25', 'µg/m³'),
+            ...concentrationPatterns('PM10', 'pm10', 'µg/m³'),
+            ...concentrationPatterns('CO', 'co', 'ppm'),
+            ...concentrationPatterns('NO2', 'no2'),
+            ...concentrationPatterns('O3', 'o3'),
+            ...concentrationPatterns('CH2O', 'ch2o', 'µg/m³'),
+            ...concentrationPatterns('RN', 'rn', 'Bq/m³'),
+            ...concentrationPatterns('SO2', 'so2'),
+            {
+                role: /^value\.pressure$/,
+                indicator: false,
+                write: false,
+                type: StateType.Number,
+                searchInParent: true,
+                name: 'PRESSURE',
+                required: false,
+                defaultRole: 'value.pressure',
+                defaultUnit: 'mbar',
+            },
+            {
+                role: /temperature(\..*)?$/,
+                indicator: false,
+                write: false,
+                type: StateType.Number,
+                searchInParent: true,
+                name: 'ACTUAL',
+                required: false,
+                defaultRole: 'value.temperature',
+                defaultUnit: '°C',
+                ignoreRole: IGNORE_SETTINGS_REGEX,
+            },
+            {
+                role: /humidity(\..*)?$/,
+                indicator: false,
+                write: false,
+                type: StateType.Number,
+                searchInParent: true,
+                name: 'HUMIDITY',
+                required: false,
+                defaultRole: 'value.humidity',
+                defaultUnit: '%',
+                ignoreRole: IGNORE_SETTINGS_REGEX,
+            },
+            SharedPatterns.working,
+            SharedPatterns.unreach,
+            SharedPatterns.lowbat,
+            SharedPatterns.maintain,
+            SharedPatterns.error,
+            SharedPatterns.battery,
+        ],
+        type: Types.airQuality,
     },
     temperature: {
         states: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@
 /** These are the names of the patterns as used internally */
 export type PatternName =
     | 'airCondition'
+    | 'airQuality'
     | 'blindButtons'
     | 'blinds'
     | 'button'
@@ -73,6 +74,7 @@ export type PatternName =
 export enum Types {
     unknown = 'unknown',
     airCondition = 'airCondition',
+    airQuality = 'airQuality',
     blind = 'blind',
     blindButtons = 'blindButtons',
     button = 'button',

--- a/test/detector.typescript.test.js
+++ b/test/detector.typescript.test.js
@@ -134,6 +134,108 @@ describe(`${name} Test Detector`, () => {
         done();
     });
 
+    it(`${name} Must detect air quality sensor with concentrations and levels`, done => {
+        const numberState = (name, role, unit) => ({
+            common: { name, type: 'number', unit, role, read: true, write: false },
+            type: 'state',
+        });
+        const objects = {
+            'matter.0.AirQuality': {
+                common: { name: 'IKEA ALPSTUGA' },
+                type: 'device',
+            },
+            'matter.0.AirQuality.airQuality': numberState('Air quality index', 'value.airquality'),
+            'matter.0.AirQuality.co2': numberState('CO2', 'value.co2', 'ppm'),
+            'matter.0.AirQuality.co2Level': numberState('CO2 level', 'value.co2.level'),
+            'matter.0.AirQuality.pm25': numberState('PM2.5', 'value.pm25', 'µg/m³'),
+            'matter.0.AirQuality.pm25Level': numberState('PM2.5 level', 'value.pm25.level'),
+            'matter.0.AirQuality.tvoc': numberState('TVOC', 'value.tvoc', 'ppb'),
+            'matter.0.AirQuality.pressure': numberState('Pressure', 'value.pressure', 'hPa'),
+            'matter.0.AirQuality.temperature': numberState('Temperature', 'value.temperature', '°C'),
+            'matter.0.AirQuality.humidity': numberState('Humidity', 'value.humidity', '%'),
+            'matter.0.AirQuality.power': {
+                common: { name: 'Power', type: 'boolean', role: 'switch.power', read: true, write: true },
+                type: 'state',
+            },
+            'matter.0.AirQuality.battery': numberState('Battery', 'value.battery', '%'),
+        };
+
+        const controls = detect(objects, {
+            id: 'matter.0.AirQuality',
+        });
+
+        validate(controls[0], Types.airQuality, {
+            AQI: 'matter.0.AirQuality.airQuality',
+            CO2: 'matter.0.AirQuality.co2',
+            CO2_LEVEL: 'matter.0.AirQuality.co2Level',
+            PM25: 'matter.0.AirQuality.pm25',
+            PM25_LEVEL: 'matter.0.AirQuality.pm25Level',
+            TVOC: 'matter.0.AirQuality.tvoc',
+            PRESSURE: 'matter.0.AirQuality.pressure',
+            ACTUAL: 'matter.0.AirQuality.temperature',
+            HUMIDITY: 'matter.0.AirQuality.humidity',
+            POWER: 'matter.0.AirQuality.power',
+            BATTERY: 'matter.0.AirQuality.battery',
+        });
+
+        done();
+    });
+
+    it(`${name} Must detect air quality sensor when the clusters are separate channels`, done => {
+        const numberState = (name, role, unit) => ({
+            common: { name, type: 'number', unit, role, read: true, write: false },
+            type: 'state',
+        });
+        const objects = {
+            'matter.0.Endpoint1': { common: { name: 'Air quality sensor' }, type: 'device' },
+            'matter.0.Endpoint1.airQuality': { common: { name: 'Air quality cluster' }, type: 'channel' },
+            'matter.0.Endpoint1.airQuality.airQuality': numberState('Air quality index', 'value.airquality'),
+            'matter.0.Endpoint1.co2': { common: { name: 'CO2 cluster' }, type: 'channel' },
+            'matter.0.Endpoint1.co2.measuredValue': numberState('CO2', 'value.co2', 'ppm'),
+            'matter.0.Endpoint1.co2.levelValue': numberState('CO2 level', 'value.co2.level'),
+            'matter.0.Endpoint1.temperature': { common: { name: 'Temperature cluster' }, type: 'channel' },
+            'matter.0.Endpoint1.temperature.measuredValue': numberState('Temperature', 'value.temperature', '°C'),
+        };
+
+        const controls = detect(objects, {
+            id: 'matter.0.Endpoint1.airQuality',
+        });
+
+        validate(controls[0], Types.airQuality, {
+            AQI: 'matter.0.Endpoint1.airQuality.airQuality',
+            CO2: 'matter.0.Endpoint1.co2.measuredValue',
+            CO2_LEVEL: 'matter.0.Endpoint1.co2.levelValue',
+            ACTUAL: 'matter.0.Endpoint1.temperature.measuredValue',
+        });
+
+        done();
+    });
+
+    it(`${name} Must detect air quality sensor from the index state alone`, done => {
+        const objects = {
+            'matter.0.AirSensor.airQuality': {
+                common: {
+                    name: 'Air quality index',
+                    type: 'number',
+                    role: 'value.airquality',
+                    read: true,
+                    write: false,
+                },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, {
+            id: 'matter.0.AirSensor.airQuality',
+        });
+
+        validate(controls[0], Types.airQuality, {
+            AQI: 'matter.0.AirSensor.airQuality',
+        });
+
+        done();
+    });
+
     it(`${name} Must detect tank level (liters) from state`, done => {
         const objects = {
             'cistern.0.Tank.Volume': {


### PR DESCRIPTION
Implements #274.

## What

New device type `airQuality`, needed to map the Matter **Air Quality Sensor** (`0x2c`), which also appears as a child endpoint of the Matter **Air Purifier** (`0x2d`).

Only `AQI` (`value.airquality`) is required — real sensors expose very different subsets of everything else.

| | states |
| --- | --- |
| required | `AQI` |
| concentrations | `CO2`, `TVOC`, `PM1`, `PM25`, `PM10`, `CO`, `NO2`, `O3`, `CH2O`, `RN`, `SO2` |
| levels | `<pollutant>_LEVEL` for each of the above |
| other optional | `POWER`, `PRESSURE`, `ACTUAL` (temperature), `HUMIDITY` |
| shared | `WORKING`, `UNREACH`, `LOWBAT`, `MAINTAIN`, `ERROR`, `BATTERY` |

Each pollutant gets a `<name>_LEVEL` companion built by `concentrationPatterns()`, matching the `levelValue` that Matter concentration-measurement clusters report next to `measuredValue` (enum `0 UNKNOWN, 1 LOW, 2 MEDIUM, 3 HIGH, 4 CRITICAL`). The IKEA ALPSTUGA reports this for CO2 and PM2.5 (ioBroker/ioBroker.matter#658).

Role ids follow ioBroker/ioBroker.docs#643 — `value.tvoc`, `value.o3`, `value.ch2o`, `value.rn`, not voc/ozone/formaldehyde/radon.

## Notes on specific choices

**Units left open** for `TVOC`, `NO2`, `O3` and `SO2`. These are reported in µg/m³ by some devices and ppb/ppm by others; `defaultUnit` is consumed by `ioBroker.devices`/`ioBroker.matter` when creating states, and lovelace derives the HA device class from `common.unit`, so fixing one unit would mislabel half the devices. `PRESSURE` defaults to `mbar` for consistency with `weatherCurrent` and the current `stateroles.md`; the pattern sets no `unit` constraint, so `hPa` matches equally.

**`searchInParent` on the concentration states.** This deviates from the issue, which marks `searchInParent` only on POWER/PRESSURE/temperature/humidity. Each pollutant is its own Matter cluster, structurally identical to `TemperatureMeasurement`, so when an adapter maps clusters to sibling channels and calls `detect()` per endpoint, the pollutants were silently dropped while `PRESSURE` and `ACTUAL` were found. The third test below covers exactly that layout.

**`value.no`** (nitrogen monoxide) from docs#643 is deliberately not wired in — no Matter cluster.

**Placement.** The pattern is inserted before `temperature`, so a sensor combining AQI with temperature/humidity is detected as `airQuality` rather than being split.

## Roles still to document

Two groups of roles used here are not in `stateroles.md` yet and need a follow-up PR against ioBroker.docs once #643 merges:

- `value.so2` — sulphur dioxide (µg/m³ or ppm)
- `value.<pollutant>.level` for `co`, `co2`, `no2`, `o3`, `ch2o`, `pm1`, `pm25`, `pm10`, `rn`, `tvoc`, `so2` — read-only, enum `0 UNKNOWN, 1 LOW, 2 MEDIUM, 3 HIGH, 4 CRITICAL`

`value.pressure` should also be documented as accepting both `mbar` and `hPa`.

## Tests

Three new tests: a full sensor with concentrations, levels, pressure, temperature, humidity, power and battery; the same data with each cluster as a separate sibling channel, detected from the AQI channel; and the index state alone.

Mutation-checked the `searchInParent` hunk: stripping it from `concentrationPatterns` makes the sibling-channel test fail with `Error: Failed checking CO2`. Full suite (48 tests) and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)