### PR TITLE
fix: keep states that lost a pattern slot available to the same pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ if (controls) {
 -->
 
 ## Changelog
+### **WORK IN PROGRESS**
+-   (@Apollon77) Fixed states that lost a pattern slot to a better candidate being marked as used, which hid them from the remaining states of the same pattern
+
 ### 5.0.15 (2026-07-10)
 -   (@GermanBluefox) Added tank level to devices
 

--- a/src/ChannelDetector.ts
+++ b/src/ChannelDetector.ts
@@ -355,9 +355,11 @@ export class ChannelDetector {
                             checkState.id = stateId;
                             mapped = true;
                             if (displacedId && !state.indicator) {
-                                const usedIndex = usedInCurrentDevice.indexOf(displacedId);
-                                if (usedIndex !== -1) {
-                                    usedInCurrentDevice.splice(usedIndex, 1);
+                                // A `notSingle` state can have been added more than once, so drop every entry
+                                for (let u = usedInCurrentDevice.length - 1; u >= 0; u--) {
+                                    if (usedInCurrentDevice[u] === displacedId) {
+                                        usedInCurrentDevice.splice(u, 1);
+                                    }
                                 }
                                 context.rejectedInCurrentDevice.push(displacedId);
                             }
@@ -369,8 +371,9 @@ export class ChannelDetector {
                 }
 
                 if (!mapped) {
-                    if (!state.indicator) {
-                        // Still available to the remaining states of this pattern, but not to another device type
+                    // Only when another candidate took the slot. Without `found` the slot is unfillable for this
+                    // state definition (a second definition of the same name), and the state stays free as before.
+                    if (found && !state.indicator) {
                         context.rejectedInCurrentDevice.push(stateId);
                     }
                 } else {
@@ -388,6 +391,7 @@ export class ChannelDetector {
                             if (
                                 (state.indicator ||
                                     (!usedInCurrentDevice.includes(cid) &&
+                                        !context.rejectedInCurrentDevice.includes(cid) &&
                                         (state.notSingle || !usedIds.includes(cid)))) &&
                                 this._applyPattern(objects, cid, state, ignoreEnums, sortedKeys)
                             ) {

--- a/src/ChannelDetector.ts
+++ b/src/ChannelDetector.ts
@@ -285,6 +285,8 @@ export class ChannelDetector {
                     result?.states.forEach((state, j) => ChannelDetector.copyState(patterns[pattern].states[j], state));
                 }
 
+                let mapped = false;
+
                 // map the detected ID to the relevant state in result - if allowed
                 if (!result.states.find(({ id }) => id === stateId)) {
                     for (const checkState of result.states) {
@@ -349,16 +351,30 @@ export class ChannelDetector {
                             }
 
                             // count++;
+                            const displacedId = checkState.id;
                             checkState.id = stateId;
-                            found = true;
+                            mapped = true;
+                            if (displacedId && !state.indicator) {
+                                const usedIndex = usedInCurrentDevice.indexOf(displacedId);
+                                if (usedIndex !== -1) {
+                                    usedInCurrentDevice.splice(usedIndex, 1);
+                                }
+                                context.rejectedInCurrentDevice.push(displacedId);
+                            }
                             break;
                         }
                     }
                 } else {
-                    found = true; // Was there before already?
+                    mapped = true; // Was there before already?
                 }
 
-                if (found) {
+                if (!mapped) {
+                    if (!state.indicator) {
+                        // Still available to the remaining states of this pattern, but not to another device type
+                        context.rejectedInCurrentDevice.push(stateId);
+                    }
+                } else {
+                    found = true;
                     if (!state.indicator) {
                         usedInCurrentDevice.push(stateId);
                     }
@@ -621,6 +637,7 @@ export class ChannelDetector {
             ignoreIndicators: ignoreIndicators || [],
             pattern: 'unknown',
             usedInCurrentDevice: [],
+            rejectedInCurrentDevice: [],
             state: {} as InternalDetectorState,
             ignoreEnums: !!options.ignoreEnums,
             sortedKeys: _keysOptional!,
@@ -640,6 +657,7 @@ export class ChannelDetector {
 
             context.pattern = pattern;
             context.usedInCurrentDevice = [];
+            context.rejectedInCurrentDevice = [];
             for (const state of patterns[pattern].states) {
                 let found = false;
 
@@ -660,6 +678,7 @@ export class ChannelDetector {
 
             // Store all used IDs in the array
             context.usedInCurrentDevice.forEach(id => usedIds.push(id));
+            context.rejectedInCurrentDevice.forEach(id => !usedIds.includes(id) && usedIds.push(id));
 
             let deviceStates: string[];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -303,6 +303,9 @@ export interface DetectorContext {
     channelStates: string[];
     usedIds: string[];
     usedInCurrentDevice: string[];
+
+    /** States that matched a pattern state but lost its slot to a better candidate */
+    rejectedInCurrentDevice: string[];
     ignoreIndicators: string[];
     result?: PatternControl;
     pattern: PatternName;

--- a/test/detector.typescript.test.js
+++ b/test/detector.typescript.test.js
@@ -1112,6 +1112,74 @@ describe(`${name} Test Detector`, () => {
         done();
     });
 
+    it('Must map a state that lost a slot to a later state of the same pattern', done => {
+        const button = (name, role) => ({
+            common: { name, type: 'boolean', role, read: true, write: false },
+            type: 'state',
+        });
+        const objects = {
+            'hm-rpc.0.Button': { common: { name: 'Button' }, type: 'channel' },
+            'hm-rpc.0.Button.press': button('Press', 'button.press'),
+            'hm-rpc.0.Button.long': button('Long press', 'button.long'),
+        };
+
+        const controls = detect(objects, { id: 'hm-rpc.0.Button' });
+
+        validate(controls[0], Types.buttonSensor, {
+            PRESS: 'hm-rpc.0.Button.press',
+            PRESS_LONG: 'hm-rpc.0.Button.long',
+        });
+
+        done();
+    });
+
+    it('Must map a state that was rejected from an already filled slot', done => {
+        const button = (name, role) => ({
+            common: { name, type: 'boolean', role, read: true, write: false },
+            type: 'state',
+        });
+        const objects = {
+            'hm-rpc.0.Button2': { common: { name: 'Button' }, type: 'channel' },
+            'hm-rpc.0.Button2.a-press': button('Press', 'button.press'),
+            'hm-rpc.0.Button2.b-long': button('Long press', 'button.long'),
+        };
+
+        const controls = detect(objects, { id: 'hm-rpc.0.Button2' });
+
+        validate(controls[0], Types.buttonSensor, {
+            PRESS: 'hm-rpc.0.Button2.a-press',
+            PRESS_LONG: 'hm-rpc.0.Button2.b-long',
+        });
+
+        done();
+    });
+
+    it('Must not offer a state that lost a slot to another device type', done => {
+        const objects = {
+            'test.0.window2': { common: { name: 'window' }, type: 'device' },
+            'test.0.window2.x-contact': {
+                common: { name: 'contact', type: 'boolean', role: 'state', read: true, write: false },
+                type: 'state',
+            },
+            'test.0.window2.a-opened': {
+                common: { name: 'opened', type: 'boolean', role: 'sensor.window', read: true, write: false },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, {
+            id: 'test.0.window2',
+            ignoreEnums: true,
+        });
+
+        expect(controls.length === 1, `Expected a single control but found ${controls.length}`);
+        validate(controls[0], Types.window, {
+            ACTUAL: 'test.0.window2.a-opened',
+        });
+
+        done();
+    });
+
     it('Must detect dimmer with power switch', done => {
         const objects = require('./dimmer.json');
 

--- a/test/detector.typescript.test.js
+++ b/test/detector.typescript.test.js
@@ -1154,6 +1154,59 @@ describe(`${name} Test Detector`, () => {
         done();
     });
 
+    it('Must keep a state that no slot of the pattern could take', done => {
+        const objects = {
+            'ac.0.AC': { common: { name: 'AC' }, type: 'device' },
+            'ac.0.AC.SET': {
+                common: { name: 'SET', role: 'level.temperature', type: 'number', unit: '°C', read: true, write: true },
+                type: 'state',
+            },
+            'ac.0.AC.MODE': {
+                common: {
+                    name: 'MODE',
+                    role: 'level.mode.airconditioner',
+                    type: 'number',
+                    states: { 0: 'AUTO' },
+                    read: true,
+                    write: true,
+                },
+                type: 'state',
+            },
+            'ac.0.AC.swingNum': {
+                common: {
+                    name: 'swingNum',
+                    role: 'level.mode.swing',
+                    type: 'number',
+                    states: { 0: 'AUTO' },
+                    read: true,
+                    write: true,
+                },
+                type: 'state',
+            },
+            'ac.0.AC.swingBool': {
+                common: { name: 'swingBool', role: 'switch.mode.swing', type: 'boolean', read: true, write: true },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, { id: 'ac.0.AC' });
+
+        validate(controls[0], Types.airCondition, {
+            SET: 'ac.0.AC.SET',
+            MODE: 'ac.0.AC.MODE',
+            SWING: 'ac.0.AC.swingNum',
+        });
+
+        // The boolean SWING definition can never fill the slot the numeric one already took, so the state
+        // must stay available to other device types instead of vanishing
+        expect(
+            controls.some(control => control.states.some(({ id }) => id === 'ac.0.AC.swingBool')),
+            'Expected ac.0.AC.swingBool to still be detected',
+        );
+
+        done();
+    });
+
     it('Must not offer a state that lost a slot to another device type', done => {
         const objects = {
             'test.0.window2': { common: { name: 'window' }, type: 'device' },


### PR DESCRIPTION
Fixes #282.

## The bug

`_testOneState()` marks a state as used by the current device even when that state did not end up mapped to any slot. The state then becomes invisible to every remaining state of the same pattern.

Two paths lead there:

1. **Rejected candidate.** The candidate matched the role regex but lost the comparison against an already mapped ID. `found` was scoped to the whole channel scan rather than to the individual candidate, so it was still `true` from an earlier successful mapping and the rejected candidate was pushed onto `usedInCurrentDevice` anyway.
2. **Displaced candidate.** The candidate won the comparison and overwrote an already mapped ID. The displaced ID kept its entry in `usedInCurrentDevice`.

Path 2 is the more common one in practice, because which of the two you hit depends on object key sort order.

## Reproduction on an existing pattern

No new device type needed. `buttonSensor`'s `PRESS` uses `/^button(\.[.\w]+)?$/`, which also matches `button.long`:

```
BASELINE: buttonSensor [ 'PRESS=hm.0.Button.press' ]
FIXED:    buttonSensor [ 'PRESS=hm.0.Button.press', 'PRESS_LONG=hm.0.Button.long' ]
```

A button exposing both `button.press` and `button.long` silently loses `PRESS_LONG` today.

Patterns with overlapping role regexes, found by sweeping all patterns for a state whose regex matches another state's `defaultRole`: `weatherForecast` (PRECIPITATION_CHANCE / PRECIPITATION), `vacuumCleaner` (BRUSH / SIDE_BRUSH), `percentage` and `levelSlider` (ACTUAL / BATTERY), `buttonSensor` (PRESS / PRESS_LONG). `airCondition` and `thermostat` also overlap on temperature, but `_applyPattern`'s read/write check rejects those candidates before the mapping stage, so they were never affected.

## Why not just scope `found`

That was the fix suggested in the issue, and it is too broad. It passes 44 tests and breaks one:

```
Must ignore favored ID when detecting via parent:
  Error: Expected type window but found door
```

The baseline returns a single `window` control. With `found` merely scoped per candidate, a phantom `door` appears and sorts first, built from the generic `role: 'state'` boolean that `window`'s ACTUAL had rejected.

The reason is that `usedInCurrentDevice` does two jobs at once: it blocks later states *within* the current pattern, and after a successful match it is merged into `usedIds`, which blocks *other device types*. The bug only concerns the first job; the second is load-bearing.

## The fix

Split the two jobs. States that lost a slot go to a new `rejectedInCurrentDevice` list, which:

- does **not** block the remaining states of the current pattern, so the intended slot can still claim them;
- **is** merged into `usedIds` once the pattern matches, so no other device type can claim them.

A state that lost a slot still belongs to this device either way, which is why the second half matters and why no new false-positive devices appear.

### Unfillable slots

A pattern may define the same state name twice — `airCondition` defines `SWING` as a Number and as a Boolean variant. The mapping loop always resolves against the *first* result state with that name, so the second definition's slot can never be filled and its candidate loses a comparison it could not win. Treating that as a rejection removed the state from detection completely:

```
MASTER: airCondition SET | MODE | SWING=swingNum
MASTER: info ACTUAL=swingBool
HEAD:   airCondition SET | MODE | SWING=swingNum      <- swingBool gone entirely
```

A candidate therefore only counts as rejected when another candidate actually took the slot during the same scan. Otherwise the state stays free, exactly as before.

Two smaller edge cases, both reachable in principle but without a reproducing test — they are guarded defensively:

- A `notSingle` non-indicator state can be pushed into `usedInCurrentDevice` more than once, so a displaced ID is removed from every position rather than only the first (`mediaPlayer` has such states).
- The `multiple` sibling scan ran after a displaced ID had been freed and could re-adopt the state it had just evicted, so it now skips rejected IDs (`weatherForecast` and `mediaPlayer` use `multiple`).

## Tests

Four new tests, one per invariant:

- a state displaced from a filled slot is picked up by a later state of the same pattern;
- a state rejected from a filled slot is picked up by a later state of the same pattern;
- a state that lost a slot is not offered to another device type (asserts a single detected control);
- a state that no slot of the pattern could take stays detectable elsewhere.

Each hunk was mutation-tested separately:

| mutation | failing test |
| --- | --- |
| full revert | both mapping tests |
| displaced-ID block disabled | *lost a slot to a later state* |
| `rejected` → `usedIds` merge removed | *not offer to another device type*, plus the pre-existing favored-ID test |
| rejected pushed to `usedInCurrentDevice` | *rejected from an already filled slot* |
| `found` guard removed | *no slot of the pattern could take* |

Full suite (49 tests) and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)