### PR TITLE
feat: add airPurifier device type

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -36,6 +36,7 @@ In [brackets] is given the class name of a device.
 
 ### Content
 * [Air conditioner [airCondition]](#air-conditioner-aircondition)
+* [Air purifier [airPurifier]](#air-purifier-airpurifier)
 * [Blinds controlled only by buttons [blindButtons]](#blinds-controlled-only-by-buttons-blindbuttons)
 * [Blinds or Shutter [blinds]](#blinds-or-shutter-blinds)
 * [Button [button]](#button-button)
@@ -101,6 +102,29 @@ Air conditioner with warming and cooling functions.
 |   | UNREACH        | indicator.maintenance.unreach |      | boolean        |    | X   |       | `/^indicator(\.maintenance)?\.unreach$/` |
 |   | MAINTAIN       | indicator.maintenance         |      | boolean        |    | X   |       | `/^indicator\.maintenance$/`             |
 |   | ERROR          | indicator.error               |      |                |    | X   |       | `/^indicator\.error$/`                   |
+
+
+### Air purifier [airPurifier]
+
+Air purifier controlled by a speed mode. Could optionally have a continuous speed level, swing, airflow direction, an ON/OFF switch and filter monitoring.
+
+| R | Name                    | Role                          | Unit | Type           | Wr | Ind | Multi | Regex                                             |
+|---|-------------------------|-------------------------------|------|----------------|----|-----|-------|---------------------------------------------------|
+| * | SPEED                   | level.mode.fan                |      | number         | W  |     |       | `/(speed｜mode)\.fan$/`                            |
+|   | POWER                   | switch.power                  |      | boolean/number | W  |     |       | `/^switch(\.power)?$/`                            |
+|   | SPEED_LEVEL             | level.fan                     | %    | number         | W  |     |       | `/^level\.fan$/`                                  |
+|   | SWING                   | level.mode.swing              |      | number         | W  |     |       | `/swing$/`                                        |
+|   | SWING                   | switch.mode.swing             |      | boolean        | W  |     |       | `/swing$/`                                        |
+|   | AIRFLOW_DIRECTION       | level.mode.airflow            |      | number         | W  |     |       | `/^level\.mode\.airflow$/`                        |
+|   | FILTER_CONDITION        | value.filter                  | %    | number         | -  |     |       | `/^value\.filter$/`                               |
+|   | FILTER_CONDITION_CARBON | value.filter.carbon           | %    | number         | -  |     |       | `/^value\.filter\.carbon$/`                       |
+|   | FILTER_CHANGE           | indicator.maintenance.filter  |      | boolean        |    | X   |       | `/^indicator\.maintenance\.filter$/`              |
+|   | WORKING                 | indicator.working             |      |                |    | X   |       | `/^indicator\.working$/`                          |
+|   | UNREACH                 | indicator.maintenance.unreach |      | boolean        |    | X   |       | `/^indicator(\.maintenance)?\.unreach$/`          |
+|   | LOWBAT                  | indicator.maintenance.lowbat  |      | boolean        |    | X   |       | `/^indicator(\.maintenance)?\.(lowbat｜battery)$/` |
+|   | MAINTAIN                | indicator.maintenance         |      | boolean        |    | X   |       | `/^indicator\.maintenance$/`                      |
+|   | ERROR                   | indicator.error               |      |                |    | X   |       | `/^indicator\.error$/`                            |
+|   | BATTERY                 | value.battery                 | %    | number         | -  |     |       | `/^value\.battery$/`                              |
 
 
 ### Blinds controlled only by buttons [blindButtons]

--- a/DEVICES.md
+++ b/DEVICES.md
@@ -112,7 +112,7 @@ Air purifier controlled by a speed mode. Could optionally have a continuous spee
 
 | R | Name                    | Role                          | Unit | Type           | Wr | Ind | Multi | Regex                                             |
 |---|-------------------------|-------------------------------|------|----------------|----|-----|-------|---------------------------------------------------|
-|   | SPEED                   | level.mode.fan                |      | number         | W  |     |       | `/(speed｜mode)\.fan$/`                            |
+| * | SPEED                   | level.mode.fan                |      | number         | W  |     |       | `/(speed｜mode)\.fan$/`                            |
 |   | POWER                   | switch.power                  |      | boolean/number | W  |     |       | `/^switch(\.power)?$/`                            |
 |   | SPEED_LEVEL             | level.fan                     | %    | number         | W  |     |       | `/^level\.fan$/`                                  |
 |   | SWING                   | level.mode.swing              |      | number         | W  |     |       | `/swing$/`                                        |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ if (controls) {
 -->
 
 ## Changelog
+### **WORK IN PROGRESS**
+-   (@Apollon77) Added new device type `airPurifier` for air purifiers (Matter Air Purifier device)
+-   (@Apollon77) Combined the fan states shared by `airCondition`, `fan` and `airPurifier` into one definition
+
 ### 5.0.15 (2026-07-10)
 -   (@GermanBluefox) Added tank level to devices
 

--- a/lib/nameOfTypes.js
+++ b/lib/nameOfTypes.js
@@ -2,6 +2,7 @@ const NameOfTypes = {
     unknown: { label: 'unknown', description: 'Unknown type' },
 
     airCondition: { label: 'Air conditioner', description: 'Air conditioner with warming and cooling functions.' },
+    airPurifier: { label: 'Air purifier', description: 'Air purifier controlled by a speed mode. Could optionally have a continuous speed level, swing, airflow direction, an ON/OFF switch and filter monitoring.' },
     blind: { label: 'Blinds or Shutter', description: 'Blinds, Shutter, Jalousie controlled by state with percent.' },
     blindButtons: { label: 'Blinds controlled only by buttons', description: 'Blinds, Shutter, Jalousie controlled by stop, up, down buttons. Position is unknown.' },
     button: { label: 'Button', description: 'Button that could be only pressed (command). It has no feedback, you can write only `true`.' },

--- a/src/typePatterns.ts
+++ b/src/typePatterns.ts
@@ -176,6 +176,102 @@ const ElectricityPatterns: { [id: string]: InternalDetectorState } = {
     },
 };
 
+/**
+ * States shared by the device types that drive a fan. They must stay identical across those types so
+ * consumers can handle them with one implementation.
+ * Types where the speed is the only mandatory control override `required` on `speed`.
+ */
+const FanPatterns: {
+    speed: InternalDetectorState;
+    power: InternalDetectorState;
+    speedLevel: InternalDetectorState;
+    swing: InternalDetectorState;
+    swingBoolean: InternalDetectorState;
+    airflowDirection: InternalDetectorState;
+} = {
+    speed: {
+        role: /(speed|mode)\.fan$/,
+        indicator: false,
+        write: true,
+        type: StateType.Number,
+        name: 'SPEED',
+        required: false,
+        defaultRole: 'level.mode.fan',
+        defaultStates: {
+            0: 'AUTO',
+            1: 'HIGH',
+            2: 'LOW',
+            3: 'MEDIUM',
+            4: 'QUIET',
+            5: 'TURBO',
+        },
+        ignoreRole: IGNORE_SETTINGS_REGEX,
+    },
+    power: {
+        role: /^switch(\.power)?$/,
+        indicator: false,
+        write: true,
+        type: [StateType.Boolean, StateType.Number],
+        searchInParent: true,
+        name: 'POWER',
+        required: false,
+        defaultRole: 'switch.power',
+    },
+    speedLevel: {
+        role: /^level\.fan$/,
+        indicator: false,
+        write: true,
+        type: StateType.Number,
+        name: 'SPEED_LEVEL',
+        required: false,
+        defaultRole: 'level.fan',
+        defaultUnit: '%',
+        ignoreRole: IGNORE_SETTINGS_REGEX,
+    },
+    swing: {
+        role: /swing$/,
+        indicator: false,
+        write: true,
+        type: StateType.Number,
+        searchInParent: true,
+        name: 'SWING',
+        required: false,
+        defaultRole: 'level.mode.swing',
+        defaultStates: {
+            0: 'AUTO',
+            1: 'HORIZONTAL',
+            2: 'STATIONARY',
+            3: 'VERTICAL',
+        },
+        ignoreRole: IGNORE_SETTINGS_REGEX,
+    },
+    swingBoolean: {
+        role: /swing$/,
+        indicator: false,
+        write: true,
+        type: StateType.Boolean,
+        searchInParent: true,
+        name: 'SWING',
+        required: false,
+        defaultRole: 'switch.mode.swing',
+        ignoreRole: IGNORE_SETTINGS_REGEX,
+    },
+    airflowDirection: {
+        role: /^level\.mode\.airflow$/,
+        indicator: false,
+        write: true,
+        type: StateType.Number,
+        name: 'AIRFLOW_DIRECTION',
+        required: false,
+        defaultRole: 'level.mode.airflow',
+        defaultStates: {
+            0: 'FORWARD',
+            1: 'REVERSE',
+        },
+        ignoreRole: IGNORE_SETTINGS_REGEX,
+    },
+};
+
 export const patterns: { [key: string]: InternalPatternControl } = {
     chart: {
         states: [{ objectType: 'chart', name: 'CHART' }],
@@ -1492,34 +1588,8 @@ export const patterns: { [key: string]: InternalPatternControl } = {
                 ignoreRole: IGNORE_SETTINGS_REGEX,
             },
             // optional
-            {
-                role: /(speed|mode)\.fan$/,
-                indicator: false,
-                write: true,
-                type: StateType.Number,
-                name: 'SPEED',
-                required: false,
-                defaultRole: 'level.mode.fan',
-                defaultStates: {
-                    0: 'AUTO',
-                    1: 'HIGH',
-                    2: 'LOW',
-                    3: 'MEDIUM',
-                    4: 'QUIET',
-                    5: 'TURBO',
-                },
-                ignoreRole: IGNORE_SETTINGS_REGEX,
-            },
-            {
-                role: /^switch(\.power)?$/,
-                indicator: false,
-                write: true,
-                type: [StateType.Boolean, StateType.Number],
-                searchInParent: true,
-                name: 'POWER',
-                required: false,
-                defaultRole: 'switch.power',
-            },
+            FanPatterns.speed,
+            FanPatterns.power,
             {
                 role: /temperature(\..*)?$/,
                 indicator: false,
@@ -1554,40 +1624,60 @@ export const patterns: { [key: string]: InternalPatternControl } = {
                 required: false,
                 defaultRole: 'switch.boost',
             },
-            {
-                role: /swing$/,
-                indicator: false,
-                write: true,
-                type: StateType.Number,
-                searchInParent: true,
-                name: 'SWING',
-                required: false,
-                defaultRole: 'level.mode.swing',
-                defaultStates: {
-                    0: 'AUTO',
-                    1: 'HORIZONTAL',
-                    2: 'STATIONARY',
-                    3: 'VERTICAL',
-                },
-                ignoreRole: IGNORE_SETTINGS_REGEX,
-            },
-            {
-                role: /swing$/,
-                indicator: false,
-                write: true,
-                type: StateType.Boolean,
-                searchInParent: true,
-                name: 'SWING',
-                required: false,
-                defaultRole: 'switch.mode.swing',
-                ignoreRole: IGNORE_SETTINGS_REGEX,
-            },
+            FanPatterns.swing,
+            FanPatterns.swingBoolean,
             ...Object.values(ElectricityPatterns),
             SharedPatterns.unreach,
             SharedPatterns.maintain,
             SharedPatterns.error,
         ],
         type: Types.airCondition,
+    },
+    airPurifier: {
+        states: [
+            { ...FanPatterns.speed, required: true },
+            // optional
+            FanPatterns.power,
+            FanPatterns.speedLevel,
+            FanPatterns.swing,
+            FanPatterns.swingBoolean,
+            FanPatterns.airflowDirection,
+            {
+                role: /^value\.filter$/,
+                indicator: false,
+                write: false,
+                type: StateType.Number,
+                name: 'FILTER_CONDITION',
+                required: false,
+                defaultRole: 'value.filter',
+                defaultUnit: '%',
+            },
+            {
+                role: /^value\.filter\.carbon$/,
+                indicator: false,
+                write: false,
+                type: StateType.Number,
+                name: 'FILTER_CONDITION_CARBON',
+                required: false,
+                defaultRole: 'value.filter.carbon',
+                defaultUnit: '%',
+            },
+            {
+                role: /^indicator\.maintenance\.filter$/,
+                indicator: true,
+                type: StateType.Boolean,
+                name: 'FILTER_CHANGE',
+                required: false,
+                defaultRole: 'indicator.maintenance.filter',
+            },
+            SharedPatterns.working,
+            SharedPatterns.unreach,
+            SharedPatterns.lowbat,
+            SharedPatterns.maintain,
+            SharedPatterns.error,
+            SharedPatterns.battery,
+        ],
+        type: Types.airPurifier,
     },
     thermostat: {
         states: [

--- a/src/typePatterns.ts
+++ b/src/typePatterns.ts
@@ -1671,8 +1671,9 @@ export const patterns: { [key: string]: InternalPatternControl } = {
     },
     airPurifier: {
         states: [
-            // optional fan controls
-            FanPatterns.speed,
+            // `FanControl` is mandatory for the Matter device, and the filter separates it from a plain `fan`
+            { ...FanPatterns.speed, required: true },
+            // optional
             FanPatterns.power,
             FanPatterns.speedLevel,
             FanPatterns.swing,

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@
 /** These are the names of the patterns as used internally */
 export type PatternName =
     | 'airCondition'
+    | 'airPurifier'
     | 'blindButtons'
     | 'blinds'
     | 'button'
@@ -73,6 +74,7 @@ export type PatternName =
 export enum Types {
     unknown = 'unknown',
     airCondition = 'airCondition',
+    airPurifier = 'airPurifier',
     blind = 'blind',
     blindButtons = 'blindButtons',
     button = 'button',

--- a/test/detector.typescript.test.js
+++ b/test/detector.typescript.test.js
@@ -550,6 +550,25 @@ describe(`${name} Test Detector`, () => {
         done();
     });
 
+    it(`${name} Must not detect a lone filter state as an air purifier`, done => {
+        const objects = {
+            'matter.0.FilterOnly': { common: { name: 'Filter' }, type: 'device' },
+            'matter.0.FilterOnly.hepa': {
+                common: { name: 'Hepa filter', type: 'number', role: 'value.filter', unit: '%', read: true, write: false },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, { id: 'matter.0.FilterOnly' });
+
+        expect(
+            !(controls || []).some(({ type }) => type === Types.airPurifier),
+            'A device without any fan control must not be an air purifier',
+        );
+
+        done();
+    });
+
     it(`${name} Must detect fan without the optional OnOff cluster`, done => {
         const objects = {
             'matter.0.SimpleFan': { common: { name: 'Fan' }, type: 'device' },

--- a/test/detector.typescript.test.js
+++ b/test/detector.typescript.test.js
@@ -326,6 +326,123 @@ describe(`${name} Test Detector`, () => {
         done();
     });
 
+    it(`${name} Must detect air purifier with both filters`, done => {
+        const writable = (name, role, states, unit) => ({
+            common: { name, type: 'number', role, states, unit, read: true, write: true },
+            type: 'state',
+        });
+        const readOnly = (name, role, unit) => ({
+            common: { name, type: 'number', role, unit, read: true, write: false },
+            type: 'state',
+        });
+        const objects = {
+            'matter.0.Purifier': { common: { name: 'Dyson Purifier' }, type: 'device' },
+            'matter.0.Purifier.fanMode': writable('Fan mode', 'level.mode.fan', { 0: 'AUTO', 1: 'HIGH' }),
+            'matter.0.Purifier.percent': writable('Percent setting', 'level.fan', undefined, '%'),
+            'matter.0.Purifier.rock': writable('Rocking', 'level.mode.swing', { 0: 'AUTO', 2: 'STATIONARY' }),
+            'matter.0.Purifier.airflow': writable('Airflow', 'level.mode.airflow', { 0: 'FORWARD', 1: 'REVERSE' }),
+            'matter.0.Purifier.onOff': {
+                common: { name: 'On/Off', type: 'boolean', role: 'switch.power', read: true, write: true },
+                type: 'state',
+            },
+            'matter.0.Purifier.hepa': readOnly('Hepa filter', 'value.filter', '%'),
+            'matter.0.Purifier.carbon': readOnly('Carbon filter', 'value.filter.carbon', '%'),
+            'matter.0.Purifier.change': {
+                common: {
+                    name: 'Change filter',
+                    type: 'boolean',
+                    role: 'indicator.maintenance.filter',
+                    read: true,
+                    write: false,
+                },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, { id: 'matter.0.Purifier' });
+
+        validate(controls[0], Types.airPurifier, {
+            SPEED: 'matter.0.Purifier.fanMode',
+            SPEED_LEVEL: 'matter.0.Purifier.percent',
+            SWING: 'matter.0.Purifier.rock',
+            AIRFLOW_DIRECTION: 'matter.0.Purifier.airflow',
+            POWER: 'matter.0.Purifier.onOff',
+            FILTER_CONDITION: 'matter.0.Purifier.hepa',
+            FILTER_CONDITION_CARBON: 'matter.0.Purifier.carbon',
+            FILTER_CHANGE: 'matter.0.Purifier.change',
+        });
+
+        done();
+    });
+
+    it(`${name} Must detect air purifier without filter monitoring`, done => {
+        const objects = {
+            'matter.0.SimplePurifier': { common: { name: 'Purifier' }, type: 'device' },
+            'matter.0.SimplePurifier.fanMode': {
+                common: {
+                    name: 'Fan mode',
+                    type: 'number',
+                    role: 'level.mode.fan',
+                    states: { 0: 'OFF', 1: 'LOW', 3: 'HIGH' },
+                    read: true,
+                    write: true,
+                },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, { id: 'matter.0.SimplePurifier' });
+
+        validate(controls[0], Types.airPurifier, {
+            SPEED: 'matter.0.SimplePurifier.fanMode',
+        });
+
+        done();
+    });
+
+    it(`${name} Must still detect an air conditioner as airCondition`, done => {
+        const objects = {
+            'alias.0.AC2': { common: { name: 'AC' }, type: 'channel' },
+            'alias.0.AC2.SET': {
+                common: { name: 'SET', role: 'level.temperature', type: 'number', unit: '°C', read: true, write: true },
+                type: 'state',
+            },
+            'alias.0.AC2.MODE': {
+                common: {
+                    name: 'MODE',
+                    role: 'level.mode.airconditioner',
+                    type: 'number',
+                    states: { 0: 'AUTO', 3: 'COOL' },
+                    read: true,
+                    write: true,
+                },
+                type: 'state',
+            },
+            'alias.0.AC2.SPEED': {
+                common: {
+                    name: 'SPEED',
+                    role: 'level.mode.fan',
+                    type: 'number',
+                    states: { 0: 'AUTO', 1: 'HIGH' },
+                    read: true,
+                    write: true,
+                },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, { id: 'alias.0.AC2' });
+
+        expect(controls.length === 1, `Expected a single control but found ${controls.length}`);
+        validate(controls[0], Types.airCondition, {
+            SET: 'alias.0.AC2.SET',
+            MODE: 'alias.0.AC2.MODE',
+            SPEED: 'alias.0.AC2.SPEED',
+        });
+
+        done();
+    });
+
     it('Must detect vacuum mihome from states', done => {
         const controls = detect('./mihome-vacuum.0.json', {
             id: 'mihome-vacuum.0',


### PR DESCRIPTION
Implements #277.

## What

New device type `airPurifier`, needed to map the Matter **Air Purifier** device (`0x2d`). It is the fan controls plus filter monitoring, without temperature control.

| | states |
| --- | --- |
| required | `SPEED` (`level.mode.fan`) |
| fan controls | `POWER`, `SPEED_LEVEL`, `SWING` (number and boolean variants), `AIRFLOW_DIRECTION` |
| filters | `FILTER_CONDITION`, `FILTER_CONDITION_CARBON`, `FILTER_CHANGE` |
| shared | `WORKING`, `UNREACH`, `LOWBAT`, `MAINTAIN`, `ERROR`, `BATTERY` |

`SPEED` is required because `FanControl` is mandatory for the Matter device type. `HepaFilterMonitoring` and `ActivatedCarbonFilterMonitoring` are optional clusters, and a purifier may carry both — the Dyson Purifier Humidify+Cool in ioBroker/ioBroker.matter#665 does.

## Shared fan states

@Garfonso asked on #277 that the state names and roles stay identical to `fan`/`airCondition` so lovelace can handle them with one implementation. Rather than copying the literals a third time, the fan-driving states now live once in a `FanPatterns` const that `airCondition` also references. Types where the speed is the only mandatory control override `required` on `speed` via a shallow spread.

The extraction is behaviour neutral, and this is checked rather than asserted: the generated `airCondition` table in `DEVICES.md` is byte-identical and all pre-existing tests pass. Sharing the objects by reference is safe because `_testOneState` deep-clones the pattern (`JSON.parse(JSON.stringify(...))`) before anything is written, `copyState`/`cleanState` only delete on that clone, and none of the shared regexes use the `/g` flag.

## Deviations from the issue

**`level.fan`, not `level.speed.fan`,** for the continuous speed. Anything ending in `speed.fan` is also matched by `airCondition`'s fan-mode regex `/(speed|mode)\.fan$/`, which would map a percent value into that discrete enum. Same reasoning and same role as #283.

**Both `SWING` variants** (number and boolean) are included, where the issue's table lists only the numeric one. This keeps the type identical to `airCondition`, which is the point of the shared const.

## Placement

`airPurifier` is registered after `airCondition`, so an air conditioner claims `level.mode.fan` as its own `SPEED` first. This is load-bearing — forcing the opposite order via `prioritizedTypes` produces:

```
airCondition SET | MODE            <- SPEED lost
airPurifier  SPEED                 <- phantom device
```

The third test below locks the correct behaviour in.

## New roles to document

`value.filter`, `value.filter.carbon` and `indicator.maintenance.filter` are not in `stateroles.md` — confirmed by grepping the live file. `value.filter` and `indicator.maintenance.filter` are also wanted by #275; `value.filter.carbon` is new here, for the second filter of a two-filter purifier.

`FILTER_CHANGE` must be declared `indicator: true`: `_applyPattern` rejects any `indicator.*` role when `indicator` is `false`.

## Tests

Three new tests: a full two-filter purifier with every optional state; a purifier with no filter monitoring; and an air conditioner still resolving to a single `airCondition` control.

Mutation-checked per hunk — breaking the carbon-filter role fails with `Failed checking FILTER_CONDITION_CARBON`, and flipping `FILTER_CHANGE` to `indicator: false` fails with `Failed checking FILTER_CHANGE`. Full suite (48 tests) and `npm run lint` pass.

## Merge order

This branch and #283 (`fan`) both insert directly after `airCondition` and will conflict there. `airPurifier` has to end up **before** `fan`, otherwise a purifier is detected as a plain fan and its filter states are lost. Whichever merges second should also swap its literals over to `FanPatterns` — for #283 that means `fan`'s SPEED / POWER / SPEED_LEVEL / SWING / AIRFLOW_DIRECTION.

🤖 Generated with [Claude Code](https://claude.com/claude-code)