### PR TITLE
feat: add the device types pressure and flow

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -54,6 +54,7 @@ In [brackets] is given the class name of a device.
 * [Fill level [fillLevel]](#fill-level-filllevel)
 * [Fire alarm sensor [fireAlarm]](#fire-alarm-sensor-firealarm)
 * [Flood alarm sensor [floodAlarm]](#flood-alarm-sensor-floodalarm)
+* [Flow sensor [flow]](#flow-sensor-flow)
 * [Gate [gate]](#gate-gate)
 * [Light with HUE color [hue]](#light-with-hue-color-hue)
 * [Humidity [humidity]](#humidity-humidity)
@@ -68,6 +69,7 @@ In [brackets] is given the class name of a device.
 * [Media player [mediaPlayer]](#media-player-mediaplayer)
 * [Motion sensor [motion]](#motion-sensor-motion)
 * [Percentage slider [percentage]](#percentage-slider-percentage)
+* [Pressure sensor [pressure]](#pressure-sensor-pressure)
 * [RGB(W) Light with different states for every color [rgb]](#rgb-w--light-with-different-states-for-every-color-rgb)
 * [RGB Light Single [rgbSingle]](#rgb-light-single-rgbsingle)
 * [RGBW Light Single [rgbwSingle]](#rgbw-light-single-rgbwsingle)
@@ -433,6 +435,21 @@ If water sensor senses water (true) or not (false).
 |   | BATTERY  | value.battery                 | %    | number  | -  |     |       | `/^value\.battery$/`                              |
 
 
+### Flow sensor [flow]
+
+Flow sensor, e.g. of water or gas, normally in m³/h.
+
+| R | Name     | Role                          | Unit | Type    | Wr | Ind | Multi | Regex                                             |
+|---|----------|-------------------------------|------|---------|----|-----|-------|---------------------------------------------------|
+| * | FLOW     | value.flow                    | m³/h | number  | -  |     |       | `/^value\.flow$/`                                 |
+|   | WORKING  | indicator.working             |      |         |    | X   |       | `/^indicator\.working$/`                          |
+|   | UNREACH  | indicator.maintenance.unreach |      | boolean |    | X   |       | `/^indicator(\.maintenance)?\.unreach$/`          |
+|   | LOWBAT   | indicator.maintenance.lowbat  |      | boolean |    | X   |       | `/^indicator(\.maintenance)?\.(lowbat｜battery)$/` |
+|   | MAINTAIN | indicator.maintenance         |      | boolean |    | X   |       | `/^indicator\.maintenance$/`                      |
+|   | ERROR    | indicator.error               |      |         |    | X   |       | `/^indicator\.error$/`                            |
+|   | BATTERY  | value.battery                 | %    | number  | -  |     |       | `/^value\.battery$/`                              |
+
+
 ### Gate [gate]
 
 Control of the gates. You can open (true) or close (false) the gate. Optionally, the exact position could exist.
@@ -685,6 +702,21 @@ Same as slider, but from 0 to 100%
 |---|----------|-------------------------------|------|---------|----|-----|-------|---------------------------------------------------|
 | * | SET      | level                         | %    | number  | W  |     |       | `/^level(\..*)?$/`                                |
 |   | ACTUAL   | value                         | %    | number  | -  |     |       | `/^value(\..*)?$/`                                |
+|   | WORKING  | indicator.working             |      |         |    | X   |       | `/^indicator\.working$/`                          |
+|   | UNREACH  | indicator.maintenance.unreach |      | boolean |    | X   |       | `/^indicator(\.maintenance)?\.unreach$/`          |
+|   | LOWBAT   | indicator.maintenance.lowbat  |      | boolean |    | X   |       | `/^indicator(\.maintenance)?\.(lowbat｜battery)$/` |
+|   | MAINTAIN | indicator.maintenance         |      | boolean |    | X   |       | `/^indicator\.maintenance$/`                      |
+|   | ERROR    | indicator.error               |      |         |    | X   |       | `/^indicator\.error$/`                            |
+|   | BATTERY  | value.battery                 | %    | number  | -  |     |       | `/^value\.battery$/`                              |
+
+
+### Pressure sensor [pressure]
+
+Pressure sensor for air or liquid pressure, normally in mbar (identical to hPa).
+
+| R | Name     | Role                          | Unit | Type    | Wr | Ind | Multi | Regex                                             |
+|---|----------|-------------------------------|------|---------|----|-----|-------|---------------------------------------------------|
+| * | PRESSURE | value.pressure                | mbar | number  | -  |     |       | `/^value\.pressure$/`                             |
 |   | WORKING  | indicator.working             |      |         |    | X   |       | `/^indicator\.working$/`                          |
 |   | UNREACH  | indicator.maintenance.unreach |      | boolean |    | X   |       | `/^indicator(\.maintenance)?\.unreach$/`          |
 |   | LOWBAT   | indicator.maintenance.lowbat  |      | boolean |    | X   |       | `/^indicator(\.maintenance)?\.(lowbat｜battery)$/` |

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ if (controls) {
 
 ## Changelog
 ### **WORK IN PROGRESS**
+-   (@Apollon77) Added new device types `pressure` and `flow` for pressure and flow sensors
 -   (@Apollon77) Added the state flag `requiredOneOf` to require at least one state out of a group instead of one specific state
 -   (@Apollon77) An `airPurifier` is now also detected when it reports only the activated carbon filter
 -   (@Apollon77) Added new device type `airPurifier` for air purifiers (Matter Air Purifier device)

--- a/lib/nameOfTypes.js
+++ b/lib/nameOfTypes.js
@@ -37,6 +37,8 @@ const NameOfTypes = {
     slider: { label: 'Slider', description: 'Slider with position set by number. Could be used for any device that is controlled by numeric value. Limits could be defined by `min`, `max` attributes. Normally from 0 (off) to 100 (full power).' },
     socket: { label: 'Socket', description: 'Socket with an ON/OFF option. Could have information about current, amperage, energy and power.' },
     temperature: { label: 'Temperature', description: 'Combined temperature and humidity sensor. Humidity is optional.' },
+    flow: { label: 'Flow sensor', description: 'Flow sensor, e.g. of water or gas, normally in m³/h.' },
+    pressure: { label: 'Pressure sensor', description: 'Pressure sensor for air or liquid pressure, normally in mbar (identical to hPa).' },
     fillLevel: { label: 'Fill level', description: 'Fill level of something (read-only). Value in `%` or in an absolute unit like liters; if `min`/`max` (or only `max`) are defined, both units can be calculated.' },
     thermostat: { label: 'Thermostat', description: 'Thermostat to be controlled by the desired temperature. Could have mode.' },
     vacuumCleaner: { label: 'Vacuum cleaner (robot)', description: '' },

--- a/src/typePatterns.ts
+++ b/src/typePatterns.ts
@@ -3280,6 +3280,48 @@ export const patterns: { [key: string]: InternalPatternControl } = {
         ],
         type: Types.illuminance,
     },
+    pressure: {
+        states: [
+            {
+                role: /^value\.pressure$/,
+                indicator: false,
+                write: false,
+                type: StateType.Number,
+                name: 'PRESSURE',
+                required: true,
+                defaultRole: 'value.pressure',
+                defaultUnit: 'mbar',
+            },
+            SharedPatterns.working,
+            SharedPatterns.unreach,
+            SharedPatterns.lowbat,
+            SharedPatterns.maintain,
+            SharedPatterns.error,
+            SharedPatterns.battery,
+        ],
+        type: Types.pressure,
+    },
+    flow: {
+        states: [
+            {
+                role: /^value\.flow$/,
+                indicator: false,
+                write: false,
+                type: StateType.Number,
+                name: 'FLOW',
+                required: true,
+                defaultRole: 'value.flow',
+                defaultUnit: 'm³/h',
+            },
+            SharedPatterns.working,
+            SharedPatterns.unreach,
+            SharedPatterns.lowbat,
+            SharedPatterns.maintain,
+            SharedPatterns.error,
+            SharedPatterns.battery,
+        ],
+        type: Types.flow,
+    },
     fillLevel: {
         states: [
             {

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ export type PatternName =
     | 'hue'
     | 'humidity'
     | 'illuminance'
+    | 'pressure'
     | 'image'
     | 'levelSlider'
     | 'light'
@@ -59,6 +60,7 @@ export type PatternName =
     | 'socket'
     | 'temperature'
     | 'fillLevel'
+    | 'flow'
     | 'thermostat'
     | 'unknown'
     | 'vacuumCleaner'
@@ -112,6 +114,8 @@ export enum Types {
     socket = 'socket',
     temperature = 'temperature',
     fillLevel = 'fillLevel',
+    flow = 'flow',
+    pressure = 'pressure',
     thermostat = 'thermostat',
     vacuumCleaner = 'vacuumCleaner',
     volume = 'volume',

--- a/test/detector.typescript.test.js
+++ b/test/detector.typescript.test.js
@@ -264,6 +264,78 @@ describe(`${name} Test Detector`, () => {
         done();
     });
 
+    it(`${name} Must detect pressure sensor`, done => {
+        const objects = {
+            'matter.0.Baro': { common: { name: 'Barometer' }, type: 'device' },
+            'matter.0.Baro.pressure': {
+                common: { name: 'Pressure', type: 'number', role: 'value.pressure', unit: 'mbar', read: true, write: false },
+                type: 'state',
+            },
+            'matter.0.Baro.battery': {
+                common: { name: 'Battery', type: 'number', role: 'value.battery', unit: '%', read: true, write: false },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, { id: 'matter.0.Baro' });
+
+        validate(controls[0], Types.pressure, {
+            PRESSURE: 'matter.0.Baro.pressure',
+            BATTERY: 'matter.0.Baro.battery',
+        });
+
+        done();
+    });
+
+    it(`${name} Must detect flow sensor`, done => {
+        const objects = {
+            'matter.0.Flow': { common: { name: 'Flow sensor' }, type: 'device' },
+            'matter.0.Flow.flow': {
+                common: { name: 'Flow', type: 'number', role: 'value.flow', unit: 'm³/h', read: true, write: false },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, { id: 'matter.0.Flow' });
+
+        validate(controls[0], Types.flow, {
+            FLOW: 'matter.0.Flow.flow',
+        });
+
+        done();
+    });
+
+    it(`${name} Must keep the pressure of a weather station with the weather station`, done => {
+        const objects = {
+            'weather.0.Current': { common: { name: 'Current weather' }, type: 'device' },
+            'weather.0.Current.temp': {
+                common: { name: 'Temperature', type: 'number', role: 'value.temperature', unit: '°C', read: true, write: false },
+                type: 'state',
+            },
+            'weather.0.Current.icon': {
+                common: { name: 'Icon', type: 'string', role: 'weather.icon', read: true, write: false },
+                type: 'state',
+            },
+            'weather.0.Current.pressure': {
+                common: { name: 'Pressure', type: 'number', role: 'value.pressure', unit: 'mbar', read: true, write: false },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, { id: 'weather.0.Current' });
+
+        expect(
+            controls.some(({ type }) => type === Types.weatherCurrent),
+            'A weather station must still be detected as weatherCurrent',
+        );
+        expect(
+            !controls.some(({ type }) => type === Types.pressure),
+            'The pressure of a weather station must stay with the weather station',
+        );
+
+        done();
+    });
+
     it('Must detect nothing if not all required states are defined', done => {
         const objects = {
             'something.0.channel': {

--- a/test/detector.typescript.test.js
+++ b/test/detector.typescript.test.js
@@ -61,7 +61,10 @@ function validate(data, detectedType, detectedFields, ignoreAdditionalDetectedSt
     }
     if (!ignoreAdditionalDetectedStates) {
         const allMatchedStates = data.states.filter(({ id }) => !!id).length;
-        expect(allMatchedStates === statesChecked,  `Expected ${statesChecked} states to be matched, but ${allMatchedStates} were found`);
+        expect(
+            allMatchedStates === statesChecked,
+            `Expected ${statesChecked} states to be matched, but ${allMatchedStates} were found`,
+        );
     }
 }
 
@@ -371,7 +374,14 @@ describe(`${name} Test Detector`, () => {
         const objects = {
             'matter.0.Baro': { common: { name: 'Barometer' }, type: 'device' },
             'matter.0.Baro.pressure': {
-                common: { name: 'Pressure', type: 'number', role: 'value.pressure', unit: 'mbar', read: true, write: false },
+                common: {
+                    name: 'Pressure',
+                    type: 'number',
+                    role: 'value.pressure',
+                    unit: 'mbar',
+                    read: true,
+                    write: false,
+                },
                 type: 'state',
             },
             'matter.0.Baro.battery': {
@@ -412,7 +422,14 @@ describe(`${name} Test Detector`, () => {
         const objects = {
             'weather.0.Current': { common: { name: 'Current weather' }, type: 'device' },
             'weather.0.Current.temp': {
-                common: { name: 'Temperature', type: 'number', role: 'value.temperature', unit: '°C', read: true, write: false },
+                common: {
+                    name: 'Temperature',
+                    type: 'number',
+                    role: 'value.temperature',
+                    unit: '°C',
+                    read: true,
+                    write: false,
+                },
                 type: 'state',
             },
             'weather.0.Current.icon': {
@@ -420,7 +437,14 @@ describe(`${name} Test Detector`, () => {
                 type: 'state',
             },
             'weather.0.Current.pressure': {
-                common: { name: 'Pressure', type: 'number', role: 'value.pressure', unit: 'mbar', read: true, write: false },
+                common: {
+                    name: 'Pressure',
+                    type: 'number',
+                    role: 'value.pressure',
+                    unit: 'mbar',
+                    read: true,
+                    write: false,
+                },
                 type: 'state',
             },
         };
@@ -710,7 +734,14 @@ describe(`${name} Test Detector`, () => {
                 type: 'state',
             },
             'matter.0.SimplePurifier.hepa': {
-                common: { name: 'Hepa filter', type: 'number', role: 'value.filter', unit: '%', read: true, write: false },
+                common: {
+                    name: 'Hepa filter',
+                    type: 'number',
+                    role: 'value.filter',
+                    unit: '%',
+                    read: true,
+                    write: false,
+                },
                 type: 'state',
             },
         };
@@ -813,7 +844,14 @@ describe(`${name} Test Detector`, () => {
         const objects = {
             'matter.0.FilterOnly': { common: { name: 'Filter' }, type: 'device' },
             'matter.0.FilterOnly.hepa': {
-                common: { name: 'Hepa filter', type: 'number', role: 'value.filter', unit: '%', read: true, write: false },
+                common: {
+                    name: 'Hepa filter',
+                    type: 'number',
+                    role: 'value.filter',
+                    unit: '%',
+                    read: true,
+                    write: false,
+                },
                 type: 'state',
             },
         };
@@ -1115,8 +1153,14 @@ describe(`${name} Test Detector`, () => {
             WIND_DIRECTION_STR: 'pirate-weather.0.weather.daily.00.windBearingText',
             HUMIDITY: 'pirate-weather.0.weather.daily.00.humidity',
             PRESSURE: 'pirate-weather.0.weather.daily.00.pressure',
-            TEMP_MIN: ['pirate-weather.0.weather.daily.00.temperatureMin', 'pirate-weather.0.weather.daily.00.temperatureLow'],
-            TEMP_MAX: ['pirate-weather.0.weather.daily.00.temperatureMax', 'pirate-weather.0.weather.daily.00.temperatureHigh'],
+            TEMP_MIN: [
+                'pirate-weather.0.weather.daily.00.temperatureMin',
+                'pirate-weather.0.weather.daily.00.temperatureLow',
+            ],
+            TEMP_MAX: [
+                'pirate-weather.0.weather.daily.00.temperatureMax',
+                'pirate-weather.0.weather.daily.00.temperatureHigh',
+            ],
             TIME_SUNRISE: 'pirate-weather.0.weather.daily.00.sunriseTime',
             TIME_SUNSET: 'pirate-weather.0.weather.daily.00.sunsetTime',
         };
@@ -1128,8 +1172,14 @@ describe(`${name} Test Detector`, () => {
             detectionDef[`WIND_DIRECTION_STR${day}`] = `pirate-weather.0.weather.daily.0${day}.windBearingText`;
             detectionDef[`HUMIDITY${day}`] = `pirate-weather.0.weather.daily.0${day}.humidity`;
             detectionDef[`PRESSURE${day}`] = `pirate-weather.0.weather.daily.0${day}.pressure`;
-            detectionDef[`TEMP_MIN${day}`] = [`pirate-weather.0.weather.daily.0${day}.temperatureMin`, `pirate-weather.0.weather.daily.0${day}.temperatureLow`];
-            detectionDef[`TEMP_MAX${day}`] = [`pirate-weather.0.weather.daily.0${day}.temperatureMax`, `pirate-weather.0.weather.daily.0${day}.temperatureHigh`];
+            detectionDef[`TEMP_MIN${day}`] = [
+                `pirate-weather.0.weather.daily.0${day}.temperatureMin`,
+                `pirate-weather.0.weather.daily.0${day}.temperatureLow`,
+            ];
+            detectionDef[`TEMP_MAX${day}`] = [
+                `pirate-weather.0.weather.daily.0${day}.temperatureMax`,
+                `pirate-weather.0.weather.daily.0${day}.temperatureHigh`,
+            ];
             detectionDef[`TIME_SUNRISE${day}`] = `pirate-weather.0.weather.daily.0${day}.sunriseTime`;
             detectionDef[`TIME_SUNSET${day}`] = `pirate-weather.0.weather.daily.0${day}.sunsetTime`;
         }
@@ -1940,7 +1990,7 @@ describe(`${name} Test Detector`, () => {
             detectParent: true,
         });
         const states = controls[0].states.filter(s => !!s.id);
-        expect(states.length=== 1, 'Should detect 1 state for dimmer with power switch');
+        expect(states.length === 1, 'Should detect 1 state for dimmer with power switch');
 
         validate(controls[0], Types.blind, {
             SET: 'mqtt.0.vantage.obergeschoss.buro.blind.rollos.percent',


### PR DESCRIPTION
Fixes #64 
Fixes #65.

## What

Two single-measurement sensor types, for the Matter **Pressure Sensor** (`0x0305`) and **Flow Sensor** (`0x0306`).

| type | required state | role | unit |
| --- | --- | --- | --- |
| `pressure` | `PRESSURE` | `value.pressure` | mbar |
| `flow` | `FLOW` | `value.flow` | m³/h |

Both carry the full shared set (`WORKING`, `UNREACH`, `LOWBAT`, `MAINTAIN`, `ERROR`, `BATTERY`), because such sensors are commonly battery powered.

Matter's `PressureMeasurement.measuredValue` is in 0.1 kPa, which is exactly hPa/mbar, so the value maps across without conversion. `FlowMeasurement.measuredValue` is m³/h ×10 — the adapter divides, the detector only needs the state.

## Placement

Both are registered with the other single-value sensors, after `weatherCurrent`. A weather station therefore keeps its `value.pressure` inside the `weatherCurrent` control instead of being split into a separate `pressure` device — covered by a test.

## Flow vs. meters

@mcm1957 noted on #65 that `value.flow` can also appear on water and gas meters, which would then be detected as `flow`. Accepted deliberately: it genuinely is a flow reading, and a meter's totalizer states use other roles and fall through as before. If metering devices ever get their own type, they can discriminate on those states.

## New role

`value.flow` (read-only, m³/h) is not in `stateroles.md` and has to be added there. `value.pressure` already exists.

## Tests

Three: a battery powered pressure sensor, a flow sensor, and a weather station keeping its pressure. Mutation-checked — pointing the flow role at a non-existent one fails the flow test. Full suite (66 tests) and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)