### PR TITLE
fix: escape every regular expression character in an object ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ if (controls) {
 
 ## Changelog
 ### **WORK IN PROGRESS**
+-   (@Apollon77) Fixed the escaping of object IDs used to build regular expressions, so IDs containing characters like `\`, `+` or `*` are matched literally
 -   (@Apollon77) Added the optional states `SPEED_LEVEL`, `AIRFLOW_DIRECTION`, `FILTER_CONDITION`, `FILTER_CONDITION_CARBON` and `FILTER_CHANGE` to `airCondition`
 -   (@Apollon77) Added the missing shared states `WORKING`, `LOWBAT` and `BATTERY` to `airCondition`. They were previously reported as a separate `info` device
 -   (@Apollon77) Added the optional states `SET_HEATING` and `SET_COOLING` to `airCondition` and `thermostat` for devices that hold a heating and a cooling setpoint at once. One of `SET`, `SET_HEATING` and `SET_COOLING` is now required instead of `SET` alone. A device whose only setpoint carries the role `level.temperature.heating` or `level.temperature.cooling` is still detected, but that state is now reported as `SET_HEATING` / `SET_COOLING` instead of `SET`

--- a/src/roleEnumUtils.ts
+++ b/src/roleEnumUtils.ts
@@ -147,16 +147,21 @@ export function getEnums(): Record<
     };
 }
 
+/** An object ID may contain any character, so all of them have to survive as literals in a regular expression */
+function escapeForRegExp(id: string): string {
+    return id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 export function getAllStatesInChannel(keys: string[], channelId: string): string[] {
     const list: string[] = [];
-    const reg = new RegExp(`^${channelId.replace(/([$^.)([\]{}])/g, '\\$1')}\\.[^.]+$`);
+    const reg = new RegExp(`^${escapeForRegExp(channelId)}\\.[^.]+$`);
     keys.forEach(_id => reg.test(_id) && list.push(_id));
     return list;
 }
 
 export function getAllStatesInDevice(keys: string[], channelId: string): string[] {
     const list: string[] = [];
-    const reg = new RegExp(`^${channelId.replace(/([$^.)([\]{}])/g, '\\$1')}\\.[^.]+\\.[^.]+$`);
+    const reg = new RegExp(`^${escapeForRegExp(channelId)}\\.[^.]+\\.[^.]+$`);
     keys.forEach(_id => reg.test(_id) && list.push(_id));
     return list;
 }

--- a/test/detector.typescript.test.js
+++ b/test/detector.typescript.test.js
@@ -895,6 +895,31 @@ describe(`${name} Test Detector`, () => {
         done();
     });
 
+    it(`${name} Must treat regular expression characters in an object ID as literals`, done => {
+        const { getAllStatesInChannel, getAllStatesInDevice } = require('../build/roleEnumUtils');
+
+        for (const channel of ['a.b', 'a\\b', 'a+b', 'a|b', 'a*b', 'a(b']) {
+            const keys = [`${channel}.x`, `${channel}.y`, 'other.x'];
+            const found = getAllStatesInChannel(keys, channel);
+            expect(
+                found.length === 2 && found[0] === `${channel}.x` && found[1] === `${channel}.y`,
+                `Expected both states of "${channel}" but found ${JSON.stringify(found)}`,
+            );
+        }
+
+        // The dot must stay escaped, so a channel must not match an ID with any character in its place
+        expect(
+            getAllStatesInChannel(['aXb.x'], 'a.b').length === 0,
+            'A dot in the channel ID must not match an arbitrary character',
+        );
+        expect(
+            getAllStatesInDevice(['a+b.c.d', 'a+b.c', 'zz.c.d'], 'a+b').join(',') === 'a+b.c.d',
+            'The device lookup must escape the ID as well',
+        );
+
+        done();
+    });
+
     it('Must detect nothing if not all required states are defined', done => {
         const objects = {
             'something.0.channel': {


### PR DESCRIPTION
Fixes the two open CodeQL `js/incomplete-sanitization` alerts (#30, #31) in `src/roleEnumUtils.ts`.

## The bug

`getAllStatesInChannel` and `getAllStatesInDevice` build a regular expression from an object ID, but escaped only `$ ^ . ) ( [ ] { }`. A **backslash** was not escaped at all — which is what CodeQL flagged — and `+`, `*`, `?` and `|` were missing too.

Measured against the old code:

```
"a.b"  -> ["a.b.x","a.b.y"]     ok
"a\b"  -> []                    not found
"a+b"  -> []                    not found
"a*b"  -> []                    not found
"a|b"  -> matched by accident   the ID became an alternation
```

An ioBroker ID may contain any character, so this is reachable with ordinary object names — no attacker needed.

## The fix

Both helpers now share one `escapeForRegExp` covering the full metacharacter set. After it, every case above returns both states, and the dot stays escaped so a channel ID still does not match an arbitrary character in its place (`a.b` must not match `aXb`).

## Not in scope

The other 8 open CodeQL alerts are `js/regex/missing-regexp-anchor` on the eight `ON_ACTUAL` role regexes. Those are the exact bug **#296** fixes — the unanchored `switch$` branch, which is also why `info.switch` was being detected as switch feedback. They are unrelated to this change.

## Tests

One new test covering `.`, `\`, `+`, `|`, `*` and `(` in a channel ID, plus the dot-must-stay-escaped case and the device variant. Mutation-checked — restoring the old escape expression fails it. Full suite (88 tests) and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)