### PR TITLE
feat: report reachability the same way on every device type

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -754,39 +754,40 @@ Lock. Could be opened (true), closed (false) or opened completely by `OPEN` stat
 
 ### Media player [mediaPlayer]
 
-| R | Name          | Role                         | Unit | Type           | Wr | Min | Max | Ind | Multi | Regex                                             |
-|---|---------------|------------------------------|------|----------------|----|-----|-----|-----|-------|---------------------------------------------------|
-| * | STATE         | media.state                  |      | boolean/number |    |     |     |     |       | `/^media\.state(\..*)?$/`                         |
-|   | PLAY          | button.play                  |      | boolean        | W  |     |     |     |       | `/^(button｜action)\.play(\..*)?$/`                |
-|   | PAUSE         | button.pause                 |      | boolean        | W  |     |     |     |       | `/^(button｜action)\.pause(\..*)?$/`               |
-|   | STOP          | button.stop                  |      | boolean        | W  |     |     |     |       | `/^(button｜action)\.stop(\..*)?$/`                |
-|   | NEXT          | button.next                  |      | boolean        | W  |     |     |     |       | `/^(button｜action)\.next(\..*)?$/`                |
-|   | PREV          | button.prev                  |      | boolean        | W  |     |     |     |       | `/^(button｜action)\.prev(\..*)?$/`                |
-|   | SHUFFLE       | media.mode.shuffle           |      | boolean        | W  |     |     |     |       | `/^media\.mode\.shuffle(\..*)?$/`                 |
-|   | REPEAT        | media.mode.repeat            |      | number         | W  |     |     |     |       | `/^media\.mode\.repeat(\..*)?$/`                  |
-|   | ARTIST        | media.artist                 |      | string         | -  |     |     |     |       | `/^media\.artist(\..*)?$/`                        |
-|   | ALBUM         | media.album                  |      | string         | -  |     |     |     |       | `/^media\.album(\..*)?$/`                         |
-|   | TITLE         | media.title                  |      | string         | -  |     |     |     |       | `/^media\.title(\..*)?$/`                         |
-|   | COVER         | media.cover                  |      | string         | -  |     |     |     |       | `/^media\.cover(\.big)?$/`                        |
-|   | COVER         |                              |      | string         | -  |     |     |     |       | `/^media\.cover(\..*)$/`                          |
-|   | DURATION      | media.duration               | sec  | number         | -  |     |     |     |       | `/^media\.duration(\..*)?$/`                      |
-|   | ELAPSED       | media.elapsed                | sec  | number         |    |     |     |     |       | `/^media\.elapsed(\..*)?$/`                       |
-|   | SEEK          | media.seek                   |      | number         | W  |     |     |     |       | `/^media\.seek(\..*)?$/`                          |
-|   | TRACK         | media.track                  |      | string         |    |     |     |     |       | `/^media\.track(\..*)?$/`                         |
-|   | EPISODE       | media.episode                |      | string         |    |     |     |     |       | `/^media\.episode(\..*)?$/`                       |
-|   | SEASON        | media.season                 |      | string         |    |     |     |     |       | `/^media\.season(\..*)?$/`                        |
-|   | VOLUME        | level.volume                 | %    | number         | W  | m   | M   |     |       | `/^level(\.volume)?$/`                            |
-|   | VOLUME_ACTUAL | value.volume                 | %    | number         | -  | m   | M   |     |       | `/^value(\.volume)?$/`                            |
-|   | MUTE          | media.mute                   |      | boolean        | W  |     |     |     |       | `/^media(\.mute)?$/`                              |
-|   | PLAYER_NAME   | media.player.name            |      | string         |    |     |     |     |       | `/^media\.player\.name$/`                         |
-|   | PLAYER_TYPE   | media.player.type            |      | string         | -  |     |     |     |       | `/^media\.player\.type/`                          |
-|   | IGNORE        |                              |      |                |    |     |     |     | x     |                                                   |
-|   | CONNECTED     | indicator.reachable          |      | boolean        |    |     |     | X   |       | `/^indicator\.reachable$/`                        |
-|   | LOWBAT        | indicator.maintenance.lowbat |      | boolean        |    |     |     | X   |       | `/^indicator(\.maintenance)?\.(lowbat｜battery)$/` |
-|   | MAINTAIN      | indicator.maintenance        |      | boolean        |    |     |     | X   |       | `/^indicator\.maintenance$/`                      |
-|   | ERROR         | indicator.error              |      |                |    |     |     | X   |       | `/^indicator\.error$/`                            |
-|   | BATTERY       | value.battery                | %    | number         | -  |     |     |     |       | `/^value\.battery$/`                              |
-|   | RSSI          | value.rssi                   | dBm  | number         | -  |     |     |     |       | `/^value\.rssi$/`                                 |
+| R | Name          | Role                          | Unit | Type           | Wr | Min | Max | Ind | Multi | Regex                                             |
+|---|---------------|-------------------------------|------|----------------|----|-----|-----|-----|-------|---------------------------------------------------|
+| * | STATE         | media.state                   |      | boolean/number |    |     |     |     |       | `/^media\.state(\..*)?$/`                         |
+|   | PLAY          | button.play                   |      | boolean        | W  |     |     |     |       | `/^(button｜action)\.play(\..*)?$/`                |
+|   | PAUSE         | button.pause                  |      | boolean        | W  |     |     |     |       | `/^(button｜action)\.pause(\..*)?$/`               |
+|   | STOP          | button.stop                   |      | boolean        | W  |     |     |     |       | `/^(button｜action)\.stop(\..*)?$/`                |
+|   | NEXT          | button.next                   |      | boolean        | W  |     |     |     |       | `/^(button｜action)\.next(\..*)?$/`                |
+|   | PREV          | button.prev                   |      | boolean        | W  |     |     |     |       | `/^(button｜action)\.prev(\..*)?$/`                |
+|   | SHUFFLE       | media.mode.shuffle            |      | boolean        | W  |     |     |     |       | `/^media\.mode\.shuffle(\..*)?$/`                 |
+|   | REPEAT        | media.mode.repeat             |      | number         | W  |     |     |     |       | `/^media\.mode\.repeat(\..*)?$/`                  |
+|   | ARTIST        | media.artist                  |      | string         | -  |     |     |     |       | `/^media\.artist(\..*)?$/`                        |
+|   | ALBUM         | media.album                   |      | string         | -  |     |     |     |       | `/^media\.album(\..*)?$/`                         |
+|   | TITLE         | media.title                   |      | string         | -  |     |     |     |       | `/^media\.title(\..*)?$/`                         |
+|   | COVER         | media.cover                   |      | string         | -  |     |     |     |       | `/^media\.cover(\.big)?$/`                        |
+|   | COVER         |                               |      | string         | -  |     |     |     |       | `/^media\.cover(\..*)$/`                          |
+|   | DURATION      | media.duration                | sec  | number         | -  |     |     |     |       | `/^media\.duration(\..*)?$/`                      |
+|   | ELAPSED       | media.elapsed                 | sec  | number         |    |     |     |     |       | `/^media\.elapsed(\..*)?$/`                       |
+|   | SEEK          | media.seek                    |      | number         | W  |     |     |     |       | `/^media\.seek(\..*)?$/`                          |
+|   | TRACK         | media.track                   |      | string         |    |     |     |     |       | `/^media\.track(\..*)?$/`                         |
+|   | EPISODE       | media.episode                 |      | string         |    |     |     |     |       | `/^media\.episode(\..*)?$/`                       |
+|   | SEASON        | media.season                  |      | string         |    |     |     |     |       | `/^media\.season(\..*)?$/`                        |
+|   | VOLUME        | level.volume                  | %    | number         | W  | m   | M   |     |       | `/^level(\.volume)?$/`                            |
+|   | VOLUME_ACTUAL | value.volume                  | %    | number         | -  | m   | M   |     |       | `/^value(\.volume)?$/`                            |
+|   | MUTE          | media.mute                    |      | boolean        | W  |     |     |     |       | `/^media(\.mute)?$/`                              |
+|   | PLAYER_NAME   | media.player.name             |      | string         |    |     |     |     |       | `/^media\.player\.name$/`                         |
+|   | PLAYER_TYPE   | media.player.type             |      | string         | -  |     |     |     |       | `/^media\.player\.type/`                          |
+|   | IGNORE        |                               |      |                |    |     |     |     | x     |                                                   |
+|   | CONNECTED     | indicator.reachable           |      | boolean        |    |     |     | X   |       | `/^indicator\.reachable$/`                        |
+|   | UNREACH       | indicator.maintenance.unreach |      | boolean        |    |     |     | X   |       | `/^indicator(\.maintenance)?\.unreach$/`          |
+|   | LOWBAT        | indicator.maintenance.lowbat  |      | boolean        |    |     |     | X   |       | `/^indicator(\.maintenance)?\.(lowbat｜battery)$/` |
+|   | MAINTAIN      | indicator.maintenance         |      | boolean        |    |     |     | X   |       | `/^indicator\.maintenance$/`                      |
+|   | ERROR         | indicator.error               |      |                |    |     |     | X   |       | `/^indicator\.error$/`                            |
+|   | BATTERY       | value.battery                 | %    | number         | -  |     |     |     |       | `/^value\.battery$/`                              |
+|   | RSSI          | value.rssi                    | dBm  | number         | -  |     |     |     |       | `/^value\.rssi$/`                                 |
 
 
 ### Motion sensor [motion]

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ if (controls) {
 
 ## Changelog
 ### **WORK IN PROGRESS**
+-   (@Apollon77) Added `UNREACH` to `media`, so every device type reports reachability the same way. `CONNECTED` (`indicator.reachable`) stays on `media` for compatibility but is deprecated, prefer `UNREACH`
 -   (@Apollon77) Added the optional state `RSSI` to all device types that describe a radio device
 -   (@Apollon77) Added the optional state `VALVE` to `thermostat` and the optional state `WORKING_MODE` to `thermostat` (`value.mode.thermostat`) and `airCondition` (`value.mode.airconditioner`)
 -   (@Apollon77) Added new device type `electricity` for devices that only measure electricity

--- a/src/typePatterns.ts
+++ b/src/typePatterns.ts
@@ -136,6 +136,7 @@ const SharedPatterns: {
         defaultStates: { 0: 'None', 1: 'Up/Open', 2: 'Down/Close', 3: 'Unknown' },
         defaultRole: 'value.direction',
     },
+    /** @deprecated Use `unreach` instead, which every other device type uses. Kept for the media player. */
     reachable: {
         role: /^indicator\.reachable$/,
         indicator: true,
@@ -719,6 +720,7 @@ export const patterns: { [key: string]: InternalPatternControl } = {
                 noSubscribe: true,
             },
             SharedPatterns.reachable,
+            SharedPatterns.unreach,
             SharedPatterns.lowbat,
             SharedPatterns.maintain,
             SharedPatterns.error,

--- a/test/detector.typescript.test.js
+++ b/test/detector.typescript.test.js
@@ -1072,7 +1072,14 @@ describe(`${name} Test Detector`, () => {
         const objects = {
             'matter.0.Trv': { common: { name: 'Radiator thermostat' }, type: 'device' },
             'matter.0.Trv.set': {
-                common: { name: 'Setpoint', type: 'number', role: 'level.temperature', unit: '°C', read: true, write: true },
+                common: {
+                    name: 'Setpoint',
+                    type: 'number',
+                    role: 'level.temperature',
+                    unit: '°C',
+                    read: true,
+                    write: true,
+                },
                 type: 'state',
             },
             'matter.0.Trv.valve': {
@@ -1107,7 +1114,14 @@ describe(`${name} Test Detector`, () => {
         const objects = {
             'matter.0.Trv2': { common: { name: 'Radiator thermostat' }, type: 'device' },
             'matter.0.Trv2.set': {
-                common: { name: 'Setpoint', type: 'number', role: 'level.temperature', unit: '°C', read: true, write: true },
+                common: {
+                    name: 'Setpoint',
+                    type: 'number',
+                    role: 'level.temperature',
+                    unit: '°C',
+                    read: true,
+                    write: true,
+                },
                 type: 'state',
             },
             'matter.0.Trv2.valve': {
@@ -1130,7 +1144,14 @@ describe(`${name} Test Detector`, () => {
         const objects = {
             'matter.0.AC5': { common: { name: 'Room AC' }, type: 'device' },
             'matter.0.AC5.set': {
-                common: { name: 'Setpoint', type: 'number', role: 'level.temperature', unit: '°C', read: true, write: true },
+                common: {
+                    name: 'Setpoint',
+                    type: 'number',
+                    role: 'level.temperature',
+                    unit: '°C',
+                    read: true,
+                    write: true,
+                },
                 type: 'state',
             },
             'matter.0.AC5.mode': {

--- a/test/detector.typescript.test.js
+++ b/test/detector.typescript.test.js
@@ -1319,6 +1319,31 @@ describe(`${name} Test Detector`, () => {
         done();
     });
 
+    it(`${name} Must offer UNREACH on every type that describes a device`, done => {
+        const patterns = ChannelDetector.getPatterns();
+
+        // `chart`, `warning` and `weatherForecast` describe a service, not a device that can be unreachable
+        const expected = ['chart', 'warning', 'weatherForecast'];
+        const actual = Object.keys(patterns)
+            .filter(type => !(patterns[type]?.states || []).some(state => state?.name === 'UNREACH'))
+            .sort();
+        expect(
+            actual.join(',') === [...expected].sort().join(','),
+            `Expected only ${expected.join(', ')} without UNREACH but found ${actual.join(', ')}`,
+        );
+
+        // CONNECTED stays on the media player for compatibility and is not spread any further
+        const withConnected = Object.keys(patterns).filter(type =>
+            (patterns[type]?.states || []).some(state => state?.name === 'CONNECTED'),
+        );
+        expect(
+            withConnected.join(',') === 'mediaPlayer',
+            `Expected CONNECTED only on mediaPlayer but found it on ${withConnected.join(', ')}`,
+        );
+
+        done();
+    });
+
     it('Must detect nothing if not all required states are defined', done => {
         const objects = {
             'something.0.channel': {


### PR DESCRIPTION
Fixes #72. Replaces #298, which took the opposite approach.

## What

`UNREACH` was on every device type except `mediaPlayer`, which had only `CONNECTED`. A consumer therefore had to read a different state depending on the type.

- `mediaPlayer` gains `UNREACH`
- `CONNECTED` (`indicator.reachable`) stays on `mediaPlayer` for compatibility and is marked `@deprecated`
- `CONNECTED` is **not** spread to the other types

```
without UNREACH:  chart, warning, weatherForecast
with CONNECTED:   mediaPlayer
```

`chart`, `warning` and `weatherForecast` keep neither — they describe a service, not a device that can be unreachable.

## Why not the other way round

#298 added `CONNECTED` alongside `UNREACH` on 41 types. That reached the same goal but left every consumer with two states to read forever and touched 41 patterns to do it. Adding the missing state to the one type that lacked it, and deprecating the odd one out, gets to a single state everywhere with a two-line change.

Nothing is removed, so no adapter breaks: a media player that reports `indicator.reachable` is still detected exactly as before.

## Tests

One test asserting both halves against **every** pattern — that only the three service types lack `UNREACH`, and that `CONNECTED` appears on `mediaPlayer` and nowhere else, so it cannot spread again unnoticed.

Mutation-checked — removing `UNREACH` from the media player fails with `found chart, mediaPlayer, warning, weatherForecast`. Full suite (105 tests) and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)