### PR TITLE
feat: add the two end contacts to the gate

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -554,6 +554,8 @@ Control of the gates. You can open (true) or close (false) the gate. Optionally,
 | * | SET            | switch.gate                   |      | boolean | W  | E    |     |       | `/^switch(\.gate)?$/`                    |
 |   | ACTUAL         | value.blind                   | %    | number  |    | E    |     |       | `/^value(\.(position｜gate))?$/`          |
 |   | STOP           | button.stop                   |      | boolean | W  | E    |     |       | `/^(button｜action)\.stop$/`              |
+|   | OPENED         | indicator.opened              |      | boolean |    |      | X   |       | `/^indicator\.opened$/`                  |
+|   | CLOSED         | indicator.closed              |      | boolean |    |      | X   |       | `/^indicator\.closed$/`                  |
 |   | DIRECTION      | indicator.direction           |      | boolean |    |      | X   |       | `/^indicator\.direction$/`               |
 |   | DIRECTION_ENUM | value.direction               |      | number  |    |      |     |       | `/^(indicator｜value)\.direction$/`       |
 |   | WORKING        | indicator.working             |      |         |    |      | X   |       | `/^indicator\.working$/`                 |

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ if (controls) {
 
 ## Changelog
 ### **WORK IN PROGRESS**
+-   (@Apollon77) Added the optional end contacts `OPENED` and `CLOSED` to `gate`
 -   (@Apollon77) Added the optional state `RSSI` to all device types that describe a radio device
 -   (@Apollon77) Added the optional state `VALVE` to `thermostat` and the optional state `WORKING_MODE` to `thermostat` (`value.mode.thermostat`) and `airCondition` (`value.mode.airconditioner`)
 -   (@Apollon77) Added new device type `electricity` for devices that only measure electricity

--- a/src/typePatterns.ts
+++ b/src/typePatterns.ts
@@ -2454,6 +2454,23 @@ export const patterns: { [key: string]: InternalPatternControl } = {
                 noSubscribe: true,
                 defaultRole: 'button.stop',
             },
+            // Two separate contacts, because a gate can also stand between fully open and fully closed
+            {
+                role: /^indicator\.opened$/,
+                indicator: true,
+                type: StateType.Boolean,
+                name: 'OPENED',
+                required: false,
+                defaultRole: 'indicator.opened',
+            },
+            {
+                role: /^indicator\.closed$/,
+                indicator: true,
+                type: StateType.Boolean,
+                name: 'CLOSED',
+                required: false,
+                defaultRole: 'indicator.closed',
+            },
             SharedPatterns.direction,
             SharedPatterns.direction_enum,
             SharedPatterns.working,

--- a/test/detector.typescript.test.js
+++ b/test/detector.typescript.test.js
@@ -1319,6 +1319,55 @@ describe(`${name} Test Detector`, () => {
         done();
     });
 
+    it(`${name} Must detect the two end contacts of a gate`, done => {
+        const contact = role => ({
+            common: { name: role, type: 'boolean', role, read: true, write: false },
+            type: 'state',
+        });
+        const objects = {
+            'test.0.Gate': { common: { name: 'Gate', role: 'gate' }, type: 'channel' },
+            'test.0.Gate.set': {
+                common: { name: 'Set', type: 'boolean', role: 'switch.gate', read: true, write: true },
+                type: 'state',
+            },
+            'test.0.Gate.opened': contact('indicator.opened'),
+            'test.0.Gate.closed': contact('indicator.closed'),
+        };
+
+        const controls = detect(objects, { id: 'test.0.Gate', ignoreEnums: true });
+
+        validate(controls[0], Types.gate, {
+            SET: 'test.0.Gate.set',
+            OPENED: 'test.0.Gate.opened',
+            CLOSED: 'test.0.Gate.closed',
+        });
+
+        done();
+    });
+
+    it(`${name} Must detect a gate that reports only one of the contacts`, done => {
+        const objects = {
+            'test.0.Gate2': { common: { name: 'Gate', role: 'gate' }, type: 'channel' },
+            'test.0.Gate2.set': {
+                common: { name: 'Set', type: 'boolean', role: 'switch.gate', read: true, write: true },
+                type: 'state',
+            },
+            'test.0.Gate2.closed': {
+                common: { name: 'Closed', type: 'boolean', role: 'indicator.closed', read: true, write: false },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, { id: 'test.0.Gate2', ignoreEnums: true });
+
+        validate(controls[0], Types.gate, {
+            SET: 'test.0.Gate2.set',
+            CLOSED: 'test.0.Gate2.closed',
+        });
+
+        done();
+    });
+
     it('Must detect nothing if not all required states are defined', done => {
         const objects = {
             'something.0.channel': {


### PR DESCRIPTION
Fixes #99.

## What

> We just need by GATE the CLOSED/OPENED state (two different) — @GermanBluefox
> ok so two states as indicators — @Apollon77

A gate could report its position as a percentage but had nowhere to put the end contacts that most gates actually have. Two optional indicators are added:

| name | role |
| --- | --- |
| `OPENED` | `indicator.opened` |
| `CLOSED` | `indicator.closed` |

## Why two states and not one

A single boolean can only say open or closed. A gate can also stand **between** the two — half open, or moving — and neither contact is then active. Two independent contacts express that; one cannot.

Both are optional, so a gate that wires up only one of them is detected too.

## On the original request

The issue started from wanting a `sensor.contact`-style state on the gate. That role now has a home of its own — the generic `contact` device type from #62 — for standalone contact sensors. For the gate the end contacts are the better fit, since they describe *which* end has been reached rather than merely that a contact is closed.

## New roles

`indicator.opened` and `indicator.closed` are not in `stateroles.md` and need to be added there. Collected for the next documentation batch.

## Tests

Two: a gate with both end contacts, and a gate that reports only one of them. Full suite (106 tests) and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)