### PR TITLE
fix: only map an object into a state definition it satisfies

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ if (controls) {
 
 ## Changelog
 ### **WORK IN PROGRESS**
+-   (@Apollon77) Fixed one object being assigned to two state definitions of the same name, which reported the swing of an air conditioner twice with a conflicting type and role
 -   (@Apollon77) Added the electricity states to `thermostat`, `fan` and `airPurifier`
 -   (@Apollon77) Added the optional state `WINDOW` to `thermostat` for the open window detection of the device
 -   (@Apollon77) Added the optional states `HOME`, `RUN_MODE`, `PROGRESS` and `PHASE` and the missing `WORKING` to `vacuumCleaner`

--- a/src/ChannelDetector.ts
+++ b/src/ChannelDetector.ts
@@ -290,7 +290,13 @@ export class ChannelDetector {
                 // map the detected ID to the relevant state in result - if allowed
                 if (!result.states.find(({ id }) => id === stateId)) {
                     for (const checkState of result.states) {
-                        if (checkState.name === state.name) {
+                        // A pattern may declare the same name more than once, e.g. a numeric and a boolean variant
+                        // of one control. The object was validated against one of them, so it may only be mapped
+                        // into a definition it actually satisfies, not merely into the first one with that name.
+                        if (
+                            checkState.name === state.name &&
+                            ChannelDetector.stateTypeMatches(checkState, objects[stateId])
+                        ) {
                             // If we already have a mapped ID, we need to decide if we keep this ID or overrule it
                             if (checkState.id) {
                                 let useThisMapping: boolean | undefined; // three-state flag
@@ -534,6 +540,18 @@ export class ChannelDetector {
         }
 
         return !excludedTypes || !excludedTypes.includes(pattern.type);
+    }
+
+    /** Whether an object satisfies the declared type of a pattern state. A state without a type accepts anything. */
+    private static stateTypeMatches(state: DetectorState | InternalDetectorState, obj?: ioBroker.Object): boolean {
+        if (!state.type) {
+            return true;
+        }
+        const type = obj?.common?.type;
+        if (!type) {
+            return true;
+        }
+        return Array.isArray(state.type) ? state.type.includes(type as StateType) : state.type === type;
     }
 
     private static allRequiredStatesFound(context: DetectorContext): context is MatchedDetectorContext {

--- a/test/detector.typescript.test.js
+++ b/test/detector.typescript.test.js
@@ -1597,6 +1597,45 @@ describe(`${name} Test Detector`, () => {
         done();
     });
 
+    it(`${name} Must assign a boolean swing to one definition only`, done => {
+        const objects = {
+            'alias.0.ac': { common: { name: 'AC', role: 'airCondition' }, type: 'channel' },
+            'alias.0.ac.SET': {
+                common: { name: 'SET', role: 'level.temperature', type: 'number', read: true, write: true },
+                type: 'state',
+            },
+            'alias.0.ac.MODE': {
+                common: {
+                    name: 'MODE',
+                    role: 'level.mode.airconditioner',
+                    type: 'number',
+                    states: { 0: 'AUTO' },
+                    read: true,
+                    write: true,
+                },
+                type: 'state',
+            },
+            'alias.0.ac.SWING_BOOLEAN': {
+                common: { name: 'SWING', role: 'switch.mode.swing', type: 'boolean', read: true, write: true },
+                type: 'state',
+            },
+        };
+
+        const controls = detect(objects, { id: 'alias.0.ac' });
+
+        // One object must not fill both SWING definitions, which would report it twice with conflicting type and role
+        const swings = controls[0].states.filter(({ name, id }) => name === 'SWING' && id);
+        expect(
+            swings.length === 1 &&
+                swings[0].id === 'alias.0.ac.SWING_BOOLEAN' &&
+                swings[0].type === 'boolean' &&
+                swings[0].defaultRole === 'switch.mode.swing',
+            `Expected one boolean SWING but found ${JSON.stringify(swings.map(({ id, type, defaultRole }) => [id, type, defaultRole]))}`,
+        );
+
+        done();
+    });
+
     it('Must detect nothing if not all required states are defined', done => {
         const objects = {
             'something.0.channel': {
@@ -3126,7 +3165,7 @@ describe(`${name} Test Detector`, () => {
         done();
     });
 
-    it('Must keep a state that no slot of the pattern could take', done => {
+    it('Must map each variant of a repeated state name to its own definition', done => {
         const objects = {
             'ac.0.AC': { common: { name: 'AC' }, type: 'device' },
             'ac.0.AC.SET': {
@@ -3163,17 +3202,14 @@ describe(`${name} Test Detector`, () => {
 
         const controls = detect(objects, { id: 'ac.0.AC' });
 
-        validate(controls[0], Types.airCondition, {
-            SET: 'ac.0.AC.SET',
-            MODE: 'ac.0.AC.MODE',
-            SWING: 'ac.0.AC.swingNum',
-        });
-
-        // The boolean SWING definition can never fill the slot the numeric one already took, so the state
-        // must stay available to other device types instead of vanishing
+        // Each SWING definition takes the state whose type it declares, so both end up on the air conditioner
+        expect(controls.length === 1, `Expected a single control but found ${controls.length}`);
+        const swings = controls[0].states.filter(({ name, id }) => name === 'SWING' && id);
         expect(
-            controls.some(control => control.states.some(({ id }) => id === 'ac.0.AC.swingBool')),
-            'Expected ac.0.AC.swingBool to still be detected',
+            swings.length === 2 &&
+                swings.some(({ id, type }) => id === 'ac.0.AC.swingNum' && type === 'number') &&
+                swings.some(({ id, type }) => id === 'ac.0.AC.swingBool' && type === 'boolean'),
+            `Expected both swing states on their own definition but found ${JSON.stringify(swings.map(({ id, type }) => [id, type]))}`,
         );
 
         done();


### PR DESCRIPTION
Fixes #294.

## The bug

`airCondition` declares `SWING` twice — a Number variant on `level.mode.swing` and a Boolean variant on `switch.mode.swing` — with the **identical** role regex `/swing$/`. Reproduced on master:

```
SET     alias.0.ac.SET            "number"    level.temperature
MODE    alias.0.ac.MODE           "number"    level.mode.airconditioner
SWING   alias.0.ac.SWING_BOOLEAN  "number"    level.mode.swing
SWING   alias.0.ac.SWING_BOOLEAN  "boolean"   switch.mode.swing
```

One object, two `SWING` entries, conflicting `type` and `defaultRole`. A consumer that renders one row per detected state shows two editable rows for a single object, and ioBroker.devices writes that object twice with contradictory `role` and `type`.

## Cause

The object is validated by `_applyPattern` against **one** definition — the boolean one — but the loop that then places it searched `result.states` for the first entry with a matching **name** and nothing more. So the boolean object was written into the *Number* definition. The `searchInParent` pass later assigned the same object to the Boolean definition too, and the guard against double assignment does not span the two passes.

## Fix

An object may only be placed in a definition whose declared `type` it satisfies. Each variant now lands in the definition that describes it:

```
boolean swing => SWING=SWING type="boolean" role=switch.mode.swing
number swing  => SWING=SWING type="number"  role=level.mode.swing
```

A definition without a declared type still accepts anything, so nothing else changes — the whole suite passes untouched apart from the one test noted below.

## One existing test changed, and why that is the point

`Must keep a state that no slot of the pattern could take` was added with #284. It asserted that a boolean swing standing next to a numeric one **vanishes from the air conditioner** and has to stay available to another device type — because back then the boolean definition was structurally unfillable.

That is exactly the symptom this fix removes: the boolean definition is no longer unfillable, so the state now lands on the air conditioner where it belongs. The test is renamed to `Must map each variant of a repeated state name to its own definition` and asserts the correct placement of both.

The related guard from #284 — a candidate that *loses a comparison* to a better one stays consumed rather than being offered to other types — is unaffected and still covered by its own test.

## Scope

`airCondition.SWING` and `vacuumCleaner.BATTERY` are the only names declared twice with an identical role regex, and only the `airCondition` pair reproduced. `media.COVER`, `warning.START` and the `DIRECTION` pairs have distinct regexes and were confirmed unaffected.

## Tests

One new test asserting a boolean swing produces exactly **one** `SWING` with the boolean type and role. Mutation-checked — removing the type check reproduces the original double assignment verbatim. Full suite (114 tests) and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)