### PR TITLE
fix: remove the regular expression anchor from a default role

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -1135,7 +1135,7 @@ Just sensor if alarm should be shown.
 |   | WEATHER               | weather.state                 |      | string  |    |     |       | `/^weather\.state$/`                              |
 |   | WIND_DIRECTION        | value.direction.wind          | °    | string  |    |     |       | `/^value\.direction\.wind$/`                      |
 |   | WIND_GUST             | value.speed.wind.gust         | km/h | number  |    |     |       | `/^value\.speed\.wind\.gust$/`                    |
-|   | WIND_SPEED            | value.speed.wind$             | km/h | number  |    |     |       | `/^value\.speed\.wind$/`                          |
+|   | WIND_SPEED            | value.speed.wind              | km/h | number  |    |     |       | `/^value\.speed\.wind$/`                          |
 |   | LOWBAT                | indicator.maintenance.lowbat  |      | boolean |    | X   |       | `/^indicator(\.maintenance)?\.(lowbat｜battery)$/` |
 |   | UNREACH               | indicator.maintenance.unreach |      | boolean |    | X   |       | `/^indicator(\.maintenance)?\.unreach$/`          |
 |   | MAINTAIN              | indicator.maintenance         |      | boolean |    | X   |       | `/^indicator\.maintenance$/`                      |

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ if (controls) {
 
 ## Changelog
 ### **WORK IN PROGRESS**
+-   (@Apollon77) Fixed the default role of the wind speed of `weatherCurrent`, which carried a regular expression anchor
 -   (@Apollon77) Fixed one object being assigned to two state definitions of the same name, which reported the swing of an air conditioner twice with a conflicting type and role
 -   (@Apollon77) Added the electricity states to `thermostat`, `fan` and `airPurifier`
 -   (@Apollon77) Added the optional state `WINDOW` to `thermostat` for the open window detection of the device

--- a/src/typePatterns.ts
+++ b/src/typePatterns.ts
@@ -2639,7 +2639,7 @@ export const patterns: { [key: string]: InternalPatternControl } = {
                 indicator: false,
                 type: StateType.Number,
                 name: 'WIND_SPEED',
-                defaultRole: 'value.speed.wind$',
+                defaultRole: 'value.speed.wind',
                 defaultUnit: 'km/h',
             },
             SharedPatterns.lowbat,

--- a/test/detector.typescript.test.js
+++ b/test/detector.typescript.test.js
@@ -1636,6 +1636,26 @@ describe(`${name} Test Detector`, () => {
         done();
     });
 
+    it(`${name} Must not leak a regular expression anchor into a default role`, done => {
+        const patterns = ChannelDetector.getPatterns();
+        const bad = [];
+
+        for (const [type, control] of Object.entries(patterns)) {
+            for (const state of control.states || []) {
+                for (const entry of Array.isArray(state) ? state : [state]) {
+                    // A default role is used to create a state, so it must be a plain role and never carry `^`, `$` or `\`
+                    if (entry?.defaultRole && /[$^\\]/.test(entry.defaultRole)) {
+                        bad.push(`${type}.${entry.name}: ${entry.defaultRole}`);
+                    }
+                }
+            }
+        }
+
+        expect(bad.length === 0, `Default roles must not contain regular expression characters: ${bad.join(', ')}`);
+
+        done();
+    });
+
     it('Must detect nothing if not all required states are defined', done => {
         const objects = {
             'something.0.channel': {


### PR DESCRIPTION
## The bug

`weatherCurrent`'s wind speed carried a stray anchor in its **default role**:

```ts
role: /^value\.speed\.wind$/,
...
defaultRole: 'value.speed.wind$',     // <- the anchor from the line above
```

`defaultRole` is not used for matching — it is what `ioBroker.devices` and `ioBroker.matter` write when they **create** a state. Anything created from this got the role `value.speed.wind$`, which no adapter and no pattern can ever match. The documented role is `value.speed.wind`, which the regex above already looks for.

## How it was found

Cross-checking every `defaultRole` the detector uses against the merged `stateroles.md`: `value.speed.wind$` came up as undocumented, while `value.speed.wind` is documented and in use. The `$` was the only difference.

## Guard

A test walks every pattern and rejects any `defaultRole` containing `^`, `$` or `\`, so the same copy-paste slip cannot reappear. Mutation-checked — restoring the typo fails with:

```
Default roles must not contain regular expression characters: weatherCurrent.WIND_SPEED: value.speed.wind$
```

Full suite (115 tests) and `npm run lint` pass. `DEVICES.md` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)