### PR TITLE
[OFFICIAL RELEASE] 6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ if (controls) {
 -->
 
 ## Changelog
-### **WORK IN PROGRESS**
+### 6.0.0 (2026-08-12)
 -   (@Apollon77) Fixed the default role of the wind speed of `weatherCurrent`, which carried a regular expression anchor
 -   (@Apollon77) Fixed one object being assigned to two state definitions of the same name, which reported the swing of an air conditioner twice with a conflicting type and role
 -   (@Apollon77) Added the electricity states to `thermostat`, `fan` and `airPurifier`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iobroker/type-detector",
-  "version": "5.0.15",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iobroker/type-detector",
-      "version": "5.0.15",
+      "version": "6.0.0",
       "license": "MIT",
       "devDependencies": {
         "@alcalzone/release-script": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iobroker/type-detector",
-  "version": "5.0.15",
+  "version": "6.0.0",
   "description": "Detects devices in ioBroker for Material, Google home, Homekit, ...",
   "author": {
     "name": "bluefox",


### PR DESCRIPTION
-   (@Apollon77) Fixed the default role of the wind speed of `weatherCurrent`, which carried a regular expression anchor
-   (@Apollon77) Fixed one object being assigned to two state definitions of the same name, which reported the swing of an air conditioner twice with a conflicting type and role
-   (@Apollon77) Added the electricity states to `thermostat`, `fan` and `airPurifier`
-   (@Apollon77) Added the optional state `WINDOW` to `thermostat` for the open window detection of the device
-   (@Apollon77) Added the optional states `HOME`, `RUN_MODE`, `PROGRESS` and `PHASE` and the missing `WORKING` to `vacuumCleaner`
-   (@Apollon77) A `vacuumCleaner` is now detected with either the cleaning mode or the new run mode, instead of requiring the cleaning mode
-   (@Apollon77) Added the optional end contacts `OPENED` and `CLOSED` to `gate`
-   (@Apollon77) Added `UNREACH` to `media`, so every device type reports reachability the same way. `CONNECTED` (`indicator.reachable`) stays on `media` for compatibility but is deprecated, prefer `UNREACH`
-   (@Apollon77) Added the optional state `RSSI` to all device types that describe a radio device
-   (@Apollon77) Added the optional state `VALVE` to `thermostat` and the optional state `WORKING_MODE` to `thermostat` (`value.mode.thermostat`) and `airCondition` (`value.mode.airconditioner`)
-   (@Apollon77) Added new device type `electricity` for devices that only measure electricity
-   (@Apollon77) The feedback state `ACTUAL` of `socket` no longer matches the generic role `state`, and `ON_ACTUAL` no longer matches any role that merely ends in `switch`
-   (@Apollon77) Fixed the escaping of object IDs used to build regular expressions, so IDs containing characters like `\`, `+` or `*` are matched literally
-   (@Apollon77) Added the optional states `SPEED_LEVEL`, `AIRFLOW_DIRECTION`, `FILTER_CONDITION`, `FILTER_CONDITION_CARBON` and `FILTER_CHANGE` to `airCondition`
-   (@Apollon77) Added the missing shared states `WORKING`, `LOWBAT` and `BATTERY` to `airCondition`. They were previously reported as a separate `info` device
-   (@Apollon77) Added the optional states `SET_HEATING` and `SET_COOLING` to `airCondition` and `thermostat` for devices that hold a heating and a cooling setpoint at once. One of `SET`, `SET_HEATING` and `SET_COOLING` is now required instead of `SET` alone. A device whose only setpoint carries the role `level.temperature.heating` or `level.temperature.cooling` is still detected, but that state is now reported as `SET_HEATING` / `SET_COOLING` instead of `SET`
-   (@Apollon77) Added the optional state `ON_TIME` to the light types, `socket`, `fan` and `airPurifier`
-   (@Apollon77) Added new device type `coAlarm` for carbon monoxide alarms
-   (@Apollon77) Added the optional states `CO`, `SEVERITY`, `MUTED` and `TEST` to `fireAlarm`, so a combined smoke and CO alarm is one device
-   (@Apollon77) Added new device type `pump` for pumps (Matter Pump device)
-   (@Apollon77) Added new device types `pressure` and `flow` for pressure and flow sensors
-   (@Apollon77) Added new device type `contact` for generic contact sensors
-   (@Apollon77) Added the optional states `ON` and `ON_ACTUAL` to `slider`, so a dimmed device that is not a light keeps its on/off in one control
-   (@Apollon77) The continuous fan speed of `fan` and `airPurifier` uses the existing role `level.speed` instead of a new role `level.fan`
-   (@Apollon77) Added the state flag `requiredOneOf` to require at least one state out of a group instead of one specific state
-   (@Apollon77) An `airPurifier` is now also detected when it reports only the activated carbon filter
-   (@Apollon77) Added new device type `airPurifier` for air purifiers (Matter Air Purifier device)
-   (@Apollon77) Fixed states that lost a pattern slot to a better candidate being marked as used, which hid them from the remaining states of the same pattern
-   (@Apollon77) Added new device type `fan` for fans (Matter Fan device)
-   (@Apollon77) Combined the fan states shared by `airCondition`, `fan` and `airPurifier` into one definition
-   (@Apollon77) Added new device type `airQuality` for air quality sensors (Matter Air Quality Sensor / Air Purifier)
-   (@Apollon77) BREAKING: Renamed the detected state name of the `direction_enum` shared pattern from `DIRECTION` to `DIRECTION_ENUM` to make it distinguishable from the boolean `direction` pattern. Affects the device types `blind`, `blindButtons`, `gate` and `lock`.